### PR TITLE
OJ-1994: Change CRI_DEV from Address-cri-dev to common-lambda-dev

### DIFF
--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
@@ -18,7 +18,7 @@ import static gov.uk.di.ipv.cri.common.api.stepDefinitions.APISteps.devAccessTok
 public class IpvCoreStubUtil {
 
     private static final String CRI_DEV =
-            Optional.ofNullable(System.getenv("CRI_DEV")).orElse("address-cri-dev");
+            Optional.ofNullable(System.getenv("CRI_DEV")).orElse("common-lambda-dev");
     private static final String API_GATEWAY_ID_PRIVATE = "API_GATEWAY_ID_PRIVATE";
 
     public static String getPrivateApiEndpoint() {


### PR DESCRIPTION
## Proposed changes
see: https://github.com/govuk-one-login/ipv-config/pull/1257
Fix: common-lambda integration test

### What changed

Change default CRI_DEV environment value to new `common-lambda-dev`

### Why did it change

B'cos common-lambda needs to run on `di-ipv-cri-dev` and also pre for when common-lambda has it's own account
defaulting to `Address-cri-dev` as before no longer makes sense

- [OJ-1994](https://govukverify.atlassian.net/browse/OJ-1994)


[OJ-1994]: https://govukverify.atlassian.net/browse/OJ-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ