### PR TITLE
LIME-881: Setup contract test class for access token contract testing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -497,6 +497,15 @@
         "is_verified": false,
         "line_number": 40
       }
+    ],
+    "accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/AccessTokenHandlerTest.java": [
+        {
+          "type": "Base64 High Entropy String",
+          "filename": "accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/AccessTokenHandlerTest.java",
+          "hashed_secret": "6b80edc528b3544cbcbd63573d0ec11efc2f5460",
+          "is_verified": false,
+          "line_number": 72
+        }
     ]
   },
   "generated_at": "2024-01-09T15:40:59Z"

--- a/accesstoken/build.gradle
+++ b/accesstoken/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
 	aspect configurations.powertools
 
-	testImplementation configurations.tests
+	testImplementation configurations.tests, configurations.pact_tests
 	testRuntimeOnly configurations.test_runtime
 }
 test {

--- a/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/AccessTokenHandlerTest.java
+++ b/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/AccessTokenHandlerTest.java
@@ -1,0 +1,152 @@
+package uk.gov.di.ipv.cri.common.api.handler.pact;
+
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.State;
+import au.com.dius.pact.provider.junit.loader.PactFolder;
+import au.com.dius.pact.provider.junit5.HttpTestTarget;
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import org.apache.http.HttpRequest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.api.handler.AccessTokenHandler;
+import uk.gov.di.ipv.cri.common.api.handler.pact.utils.Injector;
+import uk.gov.di.ipv.cri.common.api.handler.pact.utils.MockHttpServer;
+import uk.gov.di.ipv.cri.common.library.domain.SessionRequest;
+import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+import uk.gov.di.ipv.cri.common.library.service.AccessTokenService;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.service.JWTVerifier;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.common.library.util.ListUtil;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Disabled
+@Provider("PassportCriProvider")
+@PactFolder("pacts")
+@ExtendWith(MockitoExtension.class)
+class AccessTokenHandlerTest {
+
+    private static final int PORT = 5050;
+
+    @Mock private ConfigurationService configurationService;
+    @Mock private DataStore<SessionItem> dataStore;
+
+    @BeforeAll
+    static void setupServer() {}
+
+    @BeforeEach
+    void pactSetup(PactVerificationContext context) throws IOException {
+
+        Map<String, String> clientAuth = new HashMap<>();
+        clientAuth.put("audience", "dummyPassportComponentId");
+        clientAuth.put("authenticationAlg", "ES256");
+        clientAuth.put("redirectUri", "http://localhost:5050");
+        clientAuth.put(
+                "publicSigningJwkBase64",
+                "eyJrdHkiOiJFQyIsImQiOiIxeEhzTmJsQ1RHbzZRTjNLZHNEVmZXNl8wMEg1VFRaRFp6bzFQeEQ3Nm9jIiwiY3J2IjoiUC0yNTYiLCJ4IjoiSmJEbkJ1dVJVRHJadGlqMmhxWlhyVkdMcWZnQXZzaWxlalVTTTBFRFFpOCIsInkiOiIxSEdWcjZmaVVvY3B6Szh5OHJxOE9sc2tSV29WRHItNGxQVXNrUG5ldzljIn0=");
+
+        when(configurationService.getParametersForPath("/clients/ipv-core/jwtAuthentication"))
+                .thenReturn(clientAuth);
+        when(configurationService.getBearerAccessTokenTtl()).thenReturn(100L);
+
+        Injector tokenHandlerInjector =
+                new Injector(
+                        new AccessTokenHandler(
+                                new AccessTokenService(configurationService, new JWTVerifier()),
+                                new SessionService(
+                                        dataStore,
+                                        configurationService,
+                                        Clock.systemUTC(),
+                                        new ListUtil()),
+                                new EventProbe()),
+                        "/token",
+                        "/");
+        MockHttpServer.startServer(new ArrayList<>(List.of(tokenHandlerInjector)), PORT);
+        context.setTarget(new HttpTestTarget("localhost", PORT));
+    }
+
+    @State("dummyApiKey is a valid api key")
+    void dummyAPIKeyIsValid() {}
+
+    @State("dummyPassportComponentId is the passport CRI component ID")
+    void componentIdIsSetToPassportCri() {}
+
+    @State("Passport CRI uses CORE_BACK_SIGNING_PRIVATE_KEY_JWK to validate core signatures")
+    void passportIsUsingExpectedSigningKey() {}
+
+    @State("dummyAuthCode is a valid authorization code")
+    void validAuthorisationCodeSupplied() {}
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void testMethod(PactVerificationContext context, HttpRequest request) {
+        // Simulates session creation and CRI lambda completion by generating an auth code
+        long todayPlusADay =
+                LocalDate.now().plusDays(2).toEpochSecond(LocalTime.now(), ZoneOffset.UTC);
+        when(configurationService.getSessionExpirationEpoch()).thenReturn(todayPlusADay);
+        when(configurationService.getAuthorizationCodeExpirationEpoch()).thenReturn(todayPlusADay);
+
+        SessionRequest sessionRequest = new SessionRequest();
+        sessionRequest.setNotBeforeTime(new Date(todayPlusADay));
+        sessionRequest.setClientId("ipv-core");
+        sessionRequest.setAudience("dummyPassportComponentId");
+        sessionRequest.setRedirectUri(URI.create("http://localhost:5050"));
+        sessionRequest.setExpirationTime(new Date(todayPlusADay));
+        sessionRequest.setIssuer("ipv-core");
+        sessionRequest.setClientId("ipv-core");
+
+        SessionService sessionService =
+                new SessionService(
+                        dataStore, configurationService, Clock.systemUTC(), new ListUtil());
+        ArgumentCaptor<SessionItem> sessionItemArgumentCaptor =
+                ArgumentCaptor.forClass(SessionItem.class);
+
+        doNothing().when(dataStore).create(any(SessionItem.class));
+
+        UUID sessionId = sessionService.saveSession(sessionRequest);
+
+        verify(dataStore).create(sessionItemArgumentCaptor.capture());
+
+        SessionItem savedSessionitem = sessionItemArgumentCaptor.getValue();
+
+        when(dataStore.getItem(savedSessionitem.getSessionId().toString()))
+                .thenReturn(savedSessionitem);
+
+        SessionItem session = sessionService.getSession(sessionId.toString());
+        session.setAccessToken("123456789");
+
+        sessionService.createAuthorizationCode(session);
+        session.setAuthorizationCode("dummyAuthCode");
+        sessionService.updateSession(session);
+
+        when(dataStore.getItemByIndex(SessionItem.AUTHORIZATION_CODE_INDEX, "dummyAuthCode"))
+                .thenReturn(List.of(session));
+        context.verifyInteraction();
+    }
+}

--- a/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/utils/Injector.java
+++ b/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/utils/Injector.java
@@ -1,0 +1,58 @@
+package uk.gov.di.ipv.cri.common.api.handler.pact.utils;
+
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Injector {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private final RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> handler;
+    private final String endpoint;
+
+    private final String pathDescription;
+
+    private final Map<Integer, String> pathParams;
+
+    private final Map<String, Object> authorizer;
+
+    public Injector(
+            RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> handler,
+            String endpoint,
+            String pathDescription) {
+        this.endpoint = endpoint;
+        this.handler = handler;
+        this.pathDescription = pathDescription;
+        this.pathParams = new HashMap<>();
+        this.findPathParams();
+        this.authorizer = new HashMap<>();
+    }
+
+    public RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> getHandler() {
+        return handler;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public Map<Integer, String> getPathParams() {
+        return this.pathParams;
+    }
+
+    private void findPathParams() {
+        String[] arr = pathDescription.split("/");
+        for (int i = 0; i < arr.length; i++) {
+            if (arr[i].charAt(0) == '{') {
+                pathParams.put(i, arr[i].substring(1, arr.length));
+                LOGGER.info("added path param : " + pathParams.get(i) + " with key: " + i);
+            }
+        }
+    }
+}

--- a/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/utils/MockHttpServer.java
+++ b/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/utils/MockHttpServer.java
@@ -1,0 +1,22 @@
+package uk.gov.di.ipv.cri.common.api.handler.pact.utils;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.concurrent.Executors;
+
+public class MockHttpServer {
+
+    public static void startServer(ArrayList<Injector> endpointList, int port) throws IOException {
+
+        HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
+        endpointList.forEach(
+                (injector) ->
+                        server.createContext(
+                                injector.getEndpoint(), new PreLambdaHandler(injector)));
+        server.setExecutor(Executors.newCachedThreadPool()); // creates a default executor
+        server.start();
+    }
+}

--- a/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/utils/PreLambdaHandler.java
+++ b/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/utils/PreLambdaHandler.java
@@ -1,0 +1,152 @@
+package uk.gov.di.ipv.cri.common.api.handler.pact.utils;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+
+class PreLambdaHandler implements HttpHandler {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> handler;
+    private final Map<Integer, String> pathParamsFromInjector;
+
+    public PreLambdaHandler(Injector injector) {
+        this.handler = injector.getHandler();
+        this.pathParamsFromInjector = injector.getPathParams();
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+
+        try {
+            APIGatewayProxyRequestEvent request = translateRequest(exchange);
+
+            Context context = mock(Context.class);
+
+            APIGatewayProxyResponseEvent response = this.handler.handleRequest(request, context);
+
+            LOGGER.info("Response has been returned lambda handler");
+            LOGGER.info(response.getBody());
+
+            translateResponse(response, exchange);
+
+        } catch (Exception e) {
+            LOGGER.error("Error caught in handler and thrown up to server");
+            LOGGER.error(e.getMessage(), e);
+            String err = "Some error occurred";
+            exchange.sendResponseHeaders(500, err.length());
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(err.getBytes());
+            }
+        }
+    }
+
+    private Map<String, String> getHeaderMap(Headers h) {
+        return h.keySet().stream()
+                .collect(
+                        Collectors.toMap(
+                                key -> key,
+                                key -> String.join(", ", h.get(key)),
+                                (existing, replacement) -> existing));
+    }
+
+    private Map<String, String> getPathParameters(String requestURL) {
+        HashMap<String, String> pathParams = new HashMap<>();
+        String[] pathArr = requestURL.split("/");
+        if (!pathParamsFromInjector.isEmpty() && pathArr.length > 1) {
+            pathParamsFromInjector
+                    .keySet()
+                    .forEach(key -> pathParams.put(pathParamsFromInjector.get(key), pathArr[key]));
+        }
+        return pathParams;
+    }
+
+    public static Map<String, String> getQueryStringParams(URI url)
+            throws UnsupportedEncodingException {
+        Map<String, String> query_pairs = new HashMap<>();
+        String query = url.getQuery();
+        String[] pairs = query.split("&");
+        for (String pair : pairs) {
+            int idx = pair.indexOf("=");
+            query_pairs.put(
+                    URLDecoder.decode(pair.substring(0, idx), "UTF-8"),
+                    URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
+        }
+        return query_pairs;
+    }
+
+    private APIGatewayProxyRequestEvent translateRequest(HttpExchange request) throws IOException {
+
+        String requestBody = IOUtils.toString(request.getRequestBody(), StandardCharsets.UTF_8);
+        LOGGER.info("BODY FROM ORIGINAL REQUEST");
+        LOGGER.info(requestBody);
+
+        String requestPath = request.getRequestURI().getPath();
+
+        LOGGER.info(requestPath);
+
+        Headers requestHeaders = request.getRequestHeaders();
+
+        String requestId = UUID.randomUUID().toString();
+
+        APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent =
+                new APIGatewayProxyRequestEvent()
+                        .withBody(requestBody)
+                        .withHeaders(getHeaderMap(requestHeaders))
+                        .withHttpMethod(request.getRequestMethod())
+                        .withPathParameters(getPathParameters(requestPath))
+                        .withRequestContext(
+                                new APIGatewayProxyRequestEvent.ProxyRequestContext()
+                                        .withRequestId(requestId));
+        String requestQuery = request.getRequestURI().getQuery();
+        LOGGER.info("query retrieved: " + requestQuery);
+
+        if (requestQuery != null) {
+            apiGatewayProxyRequestEvent.setQueryStringParameters(
+                    getQueryStringParams(request.getRequestURI()));
+        }
+
+        LOGGER.info("BODY FROM AG FORMED REQUEST");
+        LOGGER.info(apiGatewayProxyRequestEvent.getBody());
+
+        return apiGatewayProxyRequestEvent;
+    }
+
+    private void translateResponse(APIGatewayProxyResponseEvent response, HttpExchange exchange)
+            throws IOException {
+        Integer statusCode = response.getStatusCode();
+
+        Headers serverResponseHeaders = exchange.getResponseHeaders();
+        response.getHeaders().forEach(serverResponseHeaders::set);
+        serverResponseHeaders.add("Content-Type", "application/json");
+
+        if (!response.getBody().isEmpty()) {
+            LOGGER.info("getting response body");
+            String body = response.getBody();
+            exchange.sendResponseHeaders(statusCode, body.length());
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body.getBytes());
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ subprojects {
 		ssm
 		cucumberRuntime
 		cri_common_lib
+		pact_tests
 	}
 
 	// The dynamodb enhanced package loads the apache-client as well as the spi-client, so
@@ -133,6 +134,9 @@ subprojects {
 				"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito}",
 				"org.mockito:mockito-inline:${dependencyVersions.mockito}",
 				"org.hamcrest:hamcrest:2.2"
+
+		pact_tests 'au.com.dius:pact-jvm-provider-junit5:4.0.10',
+				'software.amazon.awssdk:dynamodb:2.21.24'
 
 		test_runtime "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
 


### PR DESCRIPTION
## Proposed changes

### What changed

Added contract test for the accessTokenHandler API
This test mimics the session creation performed earlier in the journey and mocks out any calls to aws services
The test works by creating a fake api that can be called to simulate the call from the lambda to the api. This is based upon the original contract testing POC

### Why did it change

This is the first step in putting together a contract testing suite between CRI Lime and IPV core

