### PR TITLE
LIME-882: Added pact broker to the pact tests

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -87,6 +87,52 @@ jobs:
             */build/jacoco/
             */build/reports/
 
+##### Will fail until github has permissions to access the pact broker #####
+#  run-pact-tests:
+#    runs-on: ubuntu-latest
+#    needs:
+#      - build
+#    steps:
+#      - name: Check out repository code
+#        uses: actions/checkout@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: 11
+#          distribution: zulu
+#          cache: 'gradle'
+#      - name: Build Cache
+#        uses: actions/cache@v3
+#        with:
+#          path: |
+#            .gradle/
+#            */build/
+#            !*/build/reports
+#            !*/build/jacoco
+#          key: ${{ runner.os }}-build-${{ github.sha }}
+#      - name: Run Pact Tests
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          PACT_BROKER_HOST: ${{ secrets.PACT_BROKER_HOST }}
+#          PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+#          PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
+#        run: ./gradlew --parallel pactTests jacocoTestReport -x spotlessApply -x spotlessCheck
+#      - name: Upload Unit Pact Reports
+#        uses: actions/upload-artifact@v2
+#        if: failure()
+#        with:
+#          name: pact-test-reports
+#          path: |
+#            */build/reports/
+#          retention-days: 5
+#      - name: Cache Pact Test Reports
+#        uses: actions/cache@v3
+#        with:
+#          key: ${{ runner.os }}-pact-test-reports-${{ github.sha }}
+#          path: |
+#            */build/jacoco/
+#            */build/reports/
+
   run-sonar-analysis:
     runs-on: ubuntu-latest
     needs:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -506,13 +506,13 @@
       }
     ],
     "accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/AccessTokenHandlerTest.java": [
-        {
-          "type": "Base64 High Entropy String",
-          "filename": "accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/AccessTokenHandlerTest.java",
-          "hashed_secret": "6b80edc528b3544cbcbd63573d0ec11efc2f5460",
-          "is_verified": false,
-          "line_number": 72
-        }
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/AccessTokenHandlerTest.java",
+        "hashed_secret": "6b80edc528b3544cbcbd63573d0ec11efc2f5460",
+        "is_verified": false,
+        "line_number": 84
+      }
     ]
   },
   "generated_at": "2024-01-10T09:20:42Z"

--- a/accesstoken/build.gradle
+++ b/accesstoken/build.gradle
@@ -17,7 +17,9 @@ dependencies {
 	testRuntimeOnly configurations.test_runtime
 }
 test {
-	useJUnitPlatform()
+	useJUnitPlatform {
+		excludeTags 'Pact'
+	}
 	finalizedBy jacocoTestReport
 }
 jacocoTestReport {

--- a/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/AccessTokenHandlerTest.java
+++ b/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/AccessTokenHandlerTest.java
@@ -2,14 +2,15 @@ package uk.gov.di.ipv.cri.common.api.handler.pact;
 
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.State;
-import au.com.dius.pact.provider.junit.loader.PactFolder;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
 import au.com.dius.pact.provider.junit5.HttpTestTarget;
 import au.com.dius.pact.provider.junit5.PactVerificationContext;
 import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
 import org.apache.http.HttpRequest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -46,9 +47,18 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@Disabled
+// For static tests against potential new contracts
+// @PactFolder("pacts")
+// For local tests the pact details will need set as environment variables
+@Tag("Pact")
 @Provider("PassportCriProvider")
-@PactFolder("pacts")
+@PactBroker(
+        host = "${PACT_BROKER_HOST}",
+        scheme = "https",
+        authentication =
+                @PactBrokerAuth(
+                        username = "${PACT_BROKER_USERNAME}",
+                        password = "${PACT_BROKER_PASSWORD}"))
 @ExtendWith(MockitoExtension.class)
 class AccessTokenHandlerTest {
 
@@ -58,7 +68,9 @@ class AccessTokenHandlerTest {
     @Mock private DataStore<SessionItem> dataStore;
 
     @BeforeAll
-    static void setupServer() {}
+    static void setupServer() {
+        System.setProperty("pact.verifier.publishResults", "true");
+    }
 
     @BeforeEach
     void pactSetup(PactVerificationContext context) throws IOException {
@@ -88,6 +100,7 @@ class AccessTokenHandlerTest {
                         "/token",
                         "/");
         MockHttpServer.startServer(new ArrayList<>(List.of(tokenHandlerInjector)), PORT);
+
         context.setTarget(new HttpTestTarget("localhost", PORT));
     }
 

--- a/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/utils/Injector.java
+++ b/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/utils/Injector.java
@@ -20,8 +20,6 @@ public class Injector {
 
     private final Map<Integer, String> pathParams;
 
-    private final Map<String, Object> authorizer;
-
     public Injector(
             RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> handler,
             String endpoint,
@@ -31,7 +29,6 @@ public class Injector {
         this.pathDescription = pathDescription;
         this.pathParams = new HashMap<>();
         this.findPathParams();
-        this.authorizer = new HashMap<>();
     }
 
     public RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> getHandler() {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		nimbusds_oauth_version   : "9.25",
 		nimbusds_jwt_version     : "9.15.1",
 		protobuf_version         : "3.19.4",
-		junit                    : "5.8.2",
+		junit                    : "5.10.1",
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
@@ -156,6 +156,12 @@ subprojects {
 		environment "LAMBDA_TASK_ROOT", "handler"
 		filter {
 			excludeTestsMatching "uk.gov.di.ipv.cri.kbv.acceptancetest.journey.*"
+		}
+	}
+
+	tasks.register("pactTests", Test) {
+		useJUnitPlatform {
+			includeTags 'Pact'
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Add connection to pact broker and split pact tests in to there own action
Included pact tests in the pre merge checks

### Why did it change

To enable contract testing of resources prior to merging changes

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-882](https://govukverify.atlassian.net/browse/LIME-882)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ x] 3 Environment variables were added for the broker connection



[LIME-882]: https://govukverify.atlassian.net/browse/LIME-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ