### PR TITLE
OJ-2216: Added client id `ipv-core-stub-aws-build_3rdparty`

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1488,6 +1488,50 @@ Resources:
       Type: String
       Value: ES256
 
+  ##################################################################################################
+  # ipv-core-stub-aws-build_3rdparty clientId configuration
+  #################################################################################################
+  IPVCoreStubAwsBuild3rdPartyAudienceParameter:
+    Condition: IsStubEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub-aws-build_3rdparty/jwtAuthentication/audience"
+      Type: String
+      Value:
+        !FindInMap [CriAudienceMapping, !Ref CriIdentifier, !Ref Environment]
+
+  IPVCoreStubAwsBuild3rdPartyPublicSigningJwkBase64Parameter:
+    Condition: IsStubEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub-aws-build_3rdparty/jwtAuthentication/publicSigningJwkBase64"
+      Type: String
+      Value: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0yLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogImszOXVLYWNTdWtRQnJNWnJIRFRCVVpzbGl2cFhLRE5aVGc2aW5DSHdyTGMiLAogICAgInkiOiAiOEY4TG5RN3dHOWh4c1Q0YXgwQXR5N2lNR0l5aVlfWUdwM19xSVp6S28xQSIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
+
+  IPVCoreStubAwsBuild3rdPartyIssuerParameter:
+    Condition: IsStubEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub-aws-build_3rdparty/jwtAuthentication/issuer"
+      Type: String
+      Value: "https://cri-3rdparty.core.build.stubs.account.gov.uk"
+
+  IPVCoreStubAwsBuild3rdPartyRedirectURIParameter:
+    Condition: IsStubEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub-aws-build_3rdparty/jwtAuthentication/redirectUri"
+      Type: String
+      Value: "https://cri-3rdparty.core.build.stubs.account.gov.uk/callback"
+
+  IPVCoreStubAwsBuild3rdPartyAuthenticationAlgParameter:
+    Condition: IsStubEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub-aws-build_3rdparty/jwtAuthentication/authenticationAlg"
+      Type: String
+      Value: ES256
+
 Outputs:
   StackName:
     Description: "CloudFormation stack name"


### PR DESCRIPTION
## Proposed changes

### What changed
Changed issuer and redirect URI for `ipv-core-stub-aws-build_3rdparty` to `https://cri-3rdparty.core.build.stubs.account.gov.uk`

### Why did it change
There is a new instance of the core stub for `ipv-core-stub-aws-build_3rdparty` uses this URL for the issuer and redirect. As such, this needs to reflect otherwise we'll get errors when trying to use the `ipv-core-stub-aws-prod_3rdparty` client Id. 

### Issue tracking
- [OJ-2216](https://govukverify.atlassian.net/browse/OJ-2216)


[OJ-2216]: https://govukverify.atlassian.net/browse/OJ-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ