### PR TITLE
OJ-2257: Bring back JFrog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,9 @@ ext {
 }
 
 repositories {
-	mavenCentral()
-	//maven {
-	//	url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
-	//}
+	maven {
+		url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
+	}
 }
 
 spotless {
@@ -65,10 +64,9 @@ subprojects {
 	}
 
 	repositories {
-		mavenCentral()
-		//maven {
-		//	url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
-		//}
+		maven {
+			url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
+		}
 	}
 
 	configurations {


### PR DESCRIPTION
## Proposed changes

### Why did it change
JFrog subscription had expired so to unblock deployments we temporarily switched to mavenCentral

### Issue tracking
- [OJ-2257](https://govukverify.atlassian.net/browse/OJ-2257)


[OJ-2257]: https://govukverify.atlassian.net/browse/OJ-2257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ