### PR TITLE
OJ-2272: Updated  `RedirectURI` for ipv-core

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -369,8 +369,8 @@ Mappings:
     di-ipv-cri-toy-api:
       staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=toy"
     di-ipv-cri-check-hmrc-api:
-      staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=checkHmrc"
-      integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=checkHmrc"
+      staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=nino"
+      integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=nino"
       production: "https://identity.account.gov.uk/credential-issuer/callback?id=checkHmrc"
     di-ipv-cri-kbv-hmrc-api:
       staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbvHmrc"


### PR DESCRIPTION
## Proposed changes

### What changed
Updated `IPVCore1RedirectURIMapping` for ipv-core to be nino.

### Why did it change
Required for E2E testing and the current value was out of date. Core have confirmed they use `nino` as the ID

### Issue tracking
- [OJ-2272](https://govukverify.atlassian.net/browse/OJ-2272)



[OJ-2272]: https://govukverify.atlassian.net/browse/OJ-2272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ