### PR TITLE
OJ-2379: Renamed `createAccessTokenCode` to `createAccessTokenCodeAndRemoveAuthCode`

### DIFF
--- a/lambdas/src/handlers/access-token-handler.ts
+++ b/lambdas/src/handlers/access-token-handler.ts
@@ -55,7 +55,7 @@ export class AccessTokenLambda implements LambdaInterface {
             logger.info("JWT signature verified");
 
             const accessTokenResponse = await this.bearerAccessTokenFactory.create();
-            await this.sessionService.createAccessTokenCode(sessionItem, accessTokenResponse);
+            await this.sessionService.createAccessTokenCodeAndRemoveAuthCode(sessionItem, accessTokenResponse);
 
             logger.info("Access token created");
             metrics.addMetric(ACCESS_TOKEN, MetricUnits.Count, 1);

--- a/lambdas/src/services/session-service.ts
+++ b/lambdas/src/services/session-service.ts
@@ -79,12 +79,13 @@ export class SessionService {
         return dateToCheck < Math.floor(Date.now() / 1000);
     }
 
-    public async createAccessTokenCode(sessionItem: SessionItem, accessToken: BearerAccessToken) {
+    public async createAccessTokenCodeAndRemoveAuthCode(sessionItem: SessionItem, accessToken: BearerAccessToken) {
         const updateSessionCommand = new UpdateCommand({
             TableName: this.getSessionTableName(),
             Key: { sessionId: sessionItem.sessionId },
             UpdateExpression:
-                "SET accessToken=:accessTokenCode, accessTokenExpiryDate=:accessTokenExpiry REMOVE authorizationCode",
+                "SET accessToken=:accessTokenCode, accessTokenExpiryDate=:accessTokenExpiry " +
+                "REMOVE authorizationCode",
             ExpressionAttributeValues: {
                 ":accessTokenCode": `${accessToken.token_type} ${accessToken.access_token}`,
                 ":accessTokenExpiry": this.configService.getBearerAccessTokenExpirationEpoch(),

--- a/lambdas/tests/unit/services/session-service.test.ts
+++ b/lambdas/tests/unit/services/session-service.test.ts
@@ -158,7 +158,7 @@ describe("session-service", () => {
             };
             jest.spyOn(configService, "getConfigEntry").mockReturnValue("session-table-name");
             jest.spyOn(configService, "getBearerAccessTokenExpirationEpoch").mockReturnValueOnce(1675382400000);
-            await sessionService.createAccessTokenCode(sessionItem as SessionItem, accessToken);
+            await sessionService.createAccessTokenCodeAndRemoveAuthCode(sessionItem as SessionItem, accessToken);
 
             expect(mockUpdateCommand).toHaveBeenCalledWith({
                 TableName: "session-table-name",


### PR DESCRIPTION
## Proposed changes

### What changed
Renamed `createAccessTokenCode` to `createAccessTokenCodeAndRemoveAuthCode`

### Why did it change
Method name does not reflect what its actually doing which caused confusion on system behaviour. 

### Issue tracking
- [OJ-2379](https://govukverify.atlassian.net/browse/OJ-2379)



[OJ-2379]: https://govukverify.atlassian.net/browse/OJ-2379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ