### PR TITLE
OJ-2346 Updated and added tests for 403 on authorisation endpoint

### DIFF
--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.logging.Logger;
 
+import static gov.uk.di.ipv.cri.common.api.util.IpvCoreStubUtil.sendCreateAuthCodeRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -140,9 +141,7 @@ public class APISteps {
             throws URISyntaxException, IOException, InterruptedException {
         response =
                 IpvCoreStubUtil.sendAuthorizationRequest(
-                        devAuthorizationUri,
-                        currentSessionId,
-                        DEFAULT_CLIENT_ID);
+                        devAuthorizationUri, currentSessionId, DEFAULT_CLIENT_ID);
     }
 
     @When("user sends a request to access token end point")
@@ -185,6 +184,6 @@ public class APISteps {
     @When("session has an authCode")
     public void sessionHasAnAuthCode()
             throws URISyntaxException, IOException, InterruptedException {
-        //sendCreateAuthCodeRequest(currentSessionId);
+        sendCreateAuthCodeRequest(currentSessionId);
     }
 }

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.logging.Logger;
 
-import static gov.uk.di.ipv.cri.common.api.util.IpvCoreStubUtil.sendCreateAuthCodeRequest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -136,6 +135,16 @@ public class APISteps {
                         DEFAULT_CLIENT_ID);
     }
 
+    @When("user sends a request to authorization end point with access_denied")
+    public void userSendsARequestToAuthorizationEndPointWithAccessDenied()
+            throws URISyntaxException, IOException, InterruptedException {
+        response =
+                IpvCoreStubUtil.sendAuthorizationRequest(
+                        devAuthorizationUri,
+                        currentSessionId,
+                        DEFAULT_CLIENT_ID);
+    }
+
     @When("user sends a request to access token end point")
     public void userSendsARequestToAccessTokenEndPoint()
             throws URISyntaxException, IOException, InterruptedException {
@@ -159,6 +168,14 @@ public class APISteps {
         assertEquals(errorCode + ": " + errorMessage, jsonNode.get("errorSummary").asText());
     }
 
+    @And("a {string} error with code {string} is sent in the response")
+    public void aErrorIsSentInTheResponse(String errorMessage, String errorCode)
+            throws IOException {
+        JsonNode jsonNode = objectMapper.readTree(response.body());
+        assertEquals(errorCode, jsonNode.get("code").asText());
+        assertEquals(errorMessage, jsonNode.get("message").asText());
+    }
+
     @When("user sends a request to access token end point with incorrect authorization code")
     public void userSendsARequestToAccessTokenEndPointWithIncorrectAuthorizationCode()
             throws URISyntaxException, IOException, InterruptedException {
@@ -168,6 +185,6 @@ public class APISteps {
     @When("session has an authCode")
     public void sessionHasAnAuthCode()
             throws URISyntaxException, IOException, InterruptedException {
-        sendCreateAuthCodeRequest(currentSessionId);
+        //sendCreateAuthCodeRequest(currentSessionId);
     }
 }

--- a/integration-tests/src/test/resources/features/AuthorizationAPI.feature
+++ b/integration-tests/src/test/resources/features/AuthorizationAPI.feature
@@ -50,3 +50,21 @@ Feature: Authorization API
       |Java                       |TS                      |
       |TS                         |TS                      |
       |TS                         |Java                    |
+
+  @access_denied
+  Scenario Outline: access-denied is returned on /authorization endpoint
+    Given authorization JAR for test user 681
+    And Session lambda implementation is in '<SessionLambdaImplementation>'
+    When user sends a request to session API
+    Then user gets a session id
+    When session has an authCode
+    And Authorisation lambda implementation is in '<AuthLambdaImplementation>'
+    When user sends a request to authorization end point with access_denied
+    Then expect a status code of 403 in the response
+    And a "Authorization permission denied" error with code "access_denied" is sent in the response
+    Examples:
+      |SessionLambdaImplementation|AuthLambdaImplementation|
+      |Java                       |Java                    |
+      |Java                       |TS                      |
+      |TS                         |TS                      |
+      |TS                         |Java                    |

--- a/integration-tests/src/test/resources/features/AuthorizationAPI.feature
+++ b/integration-tests/src/test/resources/features/AuthorizationAPI.feature
@@ -57,7 +57,6 @@ Feature: Authorization API
     And Session lambda implementation is in '<SessionLambdaImplementation>'
     When user sends a request to session API
     Then user gets a session id
-    When session has an authCode
     And Authorisation lambda implementation is in '<AuthLambdaImplementation>'
     When user sends a request to authorization end point with access_denied
     Then expect a status code of 403 in the response

--- a/lambdas/src/common/utils/errors.ts
+++ b/lambdas/src/common/utils/errors.ts
@@ -37,20 +37,13 @@ export abstract class BaseError extends Error {
         super(message);
     }
     getErrorSummary() {
-        if (this.code) {
-            return this.code + ": " + this.message;
-        } else {
-            return this.message;
-        }
+        return this.code ? this.code + ": " + this.message : this.message;
     }
 
     getErrorDetails() {
         const error = this.getErrorSummary();
-        if (this.details) {
-            return error + " - " + this.details;
-        } else {
-            return error;
-        }
+
+        return this.details ? error + " - " + this.details : error;
     }
 }
 

--- a/lambdas/src/common/utils/errors.ts
+++ b/lambdas/src/common/utils/errors.ts
@@ -145,3 +145,11 @@ export class SessionExpiredError extends BaseError {
         this.code = 1028;
     }
 }
+
+export class AccessDeniedError extends BaseError {
+    constructor() {
+        super("Access Denied");
+        this.statusCode = 403;
+        this.code = 1029;
+    }
+}

--- a/lambdas/src/handlers/authorization-handler.ts
+++ b/lambdas/src/handlers/authorization-handler.ts
@@ -7,7 +7,7 @@ import { ConfigService } from "../common/config/config-service";
 import { AuthorizationRequestValidator } from "../services/auth-request-validator";
 import { AwsClientType, createClient } from "../common/aws-client-factory";
 import { ClientConfigKey, CommonConfigKey } from "../types/config-keys";
-import { errorPayload } from "../common/utils/errors";
+import { AccessDeniedError, errorPayload } from "../common/utils/errors";
 import { logger, metrics, tracer as _tracer } from "../common/utils/power-tool";
 import errorMiddleware from "../middlewares/error/error-middleware";
 import initialiseConfigMiddleware from "../middlewares/config/initialise-config-middleware";
@@ -43,12 +43,8 @@ export class AuthorizationLambda implements LambdaInterface {
             );
             logger.info("Session validated");
 
-            if(!sessionItem.authorizationCode){
-                return {
-                            statusCode: 403,
-                            body: JSON.stringify({code:"access_denied", message:"Authorization permission denied"})
-
-                }
+            if (!sessionItem.authorizationCode) {
+                throw new AccessDeniedError();
             }
 
             const authorizationResponse = {

--- a/lambdas/src/handlers/authorization-handler.ts
+++ b/lambdas/src/handlers/authorization-handler.ts
@@ -43,6 +43,14 @@ export class AuthorizationLambda implements LambdaInterface {
             );
             logger.info("Session validated");
 
+            if(!sessionItem.authorizationCode){
+                return {
+                            statusCode: 403,
+                            body: JSON.stringify({code:"access_denied", message:"Authorization permission denied"})
+
+                }
+            }
+
             const authorizationResponse = {
                 state: {
                     value: event.queryStringParameters?.["state"],


### PR DESCRIPTION
## Proposed changes

### What changed

Added the access_denied step definitions within the AuthorizationAPI feature file and the associated step definitions file. We updated the authorisation handler in TS to include 403 access denied response.

### Why did it change

The tests were required to test the functionality of the /authorisation endpoint as per ticket OJ-2346

### Issue tracking

[OJ-2346](https://govukverify.atlassian.net/browse/OJ-2346)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2346]: https://govukverify.atlassian.net/browse/OJ-2346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ