### PR TITLE
LIME-989: Enabling contract testing for passport

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -17,13 +17,11 @@ jobs:
     uses: ./.github/workflows/run-unit-tests-java.yml
 
   pact-tests:
-    # Disabled until all contracts are deployed to the broker
-    if: false
     name: Pact tests
     strategy:
       fail-fast: false
       matrix:
-        CRI_PROVIDER: ["PassportCriProvider"]
+        CRI_PROVIDER: ["PassportTokenProvider","DrivingLicenceTokenProvider","FraudTokenProvider"]
     uses: ./.github/workflows/run-pact-tests.yml
     with:
       CRI_UNDER_TEST: ${{ matrix.CRI_PROVIDER }}

--- a/.github/workflows/run-pact-tests.yml
+++ b/.github/workflows/run-pact-tests.yml
@@ -10,10 +10,6 @@ on:
       pact-broker-username: { required: true }
       pact-broker-password: { required: true }
 
-concurrency:
-  group: pact-tests-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
-
 defaults:
   run:
     shell: bash

--- a/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/utils/MockHttpServer.java
+++ b/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/utils/MockHttpServer.java
@@ -9,14 +9,20 @@ import java.util.concurrent.Executors;
 
 public class MockHttpServer {
 
+    private static HttpServer server;
+
     public static void startServer(ArrayList<Injector> endpointList, int port) throws IOException {
 
-        HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
+        server = HttpServer.create(new InetSocketAddress(port), 0);
         endpointList.forEach(
                 (injector) ->
                         server.createContext(
                                 injector.getEndpoint(), new PreLambdaHandler(injector)));
         server.setExecutor(Executors.newCachedThreadPool()); // creates a default executor
         server.start();
+    }
+
+    public static void stopServer() {
+        server.stop(0);
     }
 }

--- a/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/utils/PreLambdaHandler.java
+++ b/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/utils/PreLambdaHandler.java
@@ -17,6 +17,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -108,6 +109,15 @@ class PreLambdaHandler implements HttpHandler {
         Headers requestHeaders = request.getRequestHeaders();
 
         String requestId = UUID.randomUUID().toString();
+
+        if (requestBody.contains("dummyInvalidAuthCode")) {
+            // replicate bad request
+            String[] jwtComponents = requestBody.split("&");
+            requestBody =
+                    Arrays.stream(jwtComponents)
+                            .filter(x -> !x.contains("dummyInvalidAuthCode"))
+                            .collect(Collectors.joining("&"));
+        }
 
         APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent =
                 new APIGatewayProxyRequestEvent()

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	testImplementation "org.apache.httpcomponents:httpclient:$apacheHttpClient"
 	testImplementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterapi"
 	testImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabind"
+	testImplementation "org.junit.jupiter:junit-jupiter-engine:$junitJupiterapi"
 }
 
 configurations {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enabled contract testing in the common lambdas for the passport cri access token

### Why did it change

To enable contract testing as a pre-merge step

