### PR TITLE
OJ-2441: remove pass environment references

### DIFF
--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/stepDefinitions/APISteps.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.logging.Logger;
 
@@ -32,9 +31,9 @@ public class APISteps {
     private static final String DEFAULT_REDIRECT_URI =
             (REDIRECT_URI.toLowerCase().startsWith("http"))
                     ? REDIRECT_URI + "/callback"
-                    : "https://di-ipv-core-stub.london.cloudapps.digital/callback";
+                    : "https://cri.core.build.stubs.account.gov.uk/callback";
     private static final String DEFAULT_CLIENT_ID =
-            Optional.ofNullable(System.getenv("DEFAULT_CLIENT_ID")).orElse("ipv-core-stub");
+            System.getenv().getOrDefault("DEFAULT_CLIENT_ID", "ipv-core-stub-aws-build");
     private String currentAuthorizationCode;
     private String sessionRequestBody;
     private String currentSessionId;

--- a/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
+++ b/integration-tests/src/test/java/gov/uk/di/ipv/cri/common/api/util/IpvCoreStubUtil.java
@@ -18,7 +18,7 @@ import static gov.uk.di.ipv.cri.common.api.stepDefinitions.APISteps.devAccessTok
 public class IpvCoreStubUtil {
 
     private static final String CRI_DEV =
-            Optional.ofNullable(System.getenv("CRI_DEV")).orElse("common-lambda-dev");
+            System.getenv().getOrDefault("CRI_DEV", "common-lambda-dev");
     private static final String API_GATEWAY_ID_PRIVATE = "API_GATEWAY_ID_PRIVATE";
 
     public static String getPrivateApiEndpoint() {

--- a/lambdas/src/common/utils/errors.ts
+++ b/lambdas/src/common/utils/errors.ts
@@ -31,7 +31,7 @@ export abstract class BaseError extends Error {
     constructor(
         public readonly message: string,
         public statusCode?: number,
-        public code?: number,
+        public code?: number | string,
         public readonly details?: string,
     ) {
         super(message);
@@ -141,8 +141,8 @@ export class SessionExpiredError extends BaseError {
 
 export class AccessDeniedError extends BaseError {
     constructor() {
-        super("Access Denied");
+        super("Authorization permission denied");
         this.statusCode = 403;
-        this.code = 1029;
+        this.code = "access_denied";
     }
 }

--- a/lambdas/tests/unit/handlers/authorization-handler.test.ts
+++ b/lambdas/tests/unit/handlers/authorization-handler.test.ts
@@ -205,13 +205,13 @@ describe("authorization-handler.ts", () => {
                 expect(result).toEqual({
                     statusCode: 403,
                     body: JSON.stringify({
-                        message: "Access Denied",
-                        code: 1029,
-                        errorSummary: "1029: Access Denied",
+                        message: "Authorization permission denied",
+                        code: "access_denied",
+                        errorSummary: "access_denied: Authorization permission denied",
                     }),
                 });
                 expect(loggerSpyError).toHaveBeenCalledWith(
-                    "Authorization Lambda error occurred: 1029: Access Denied",
+                    "Authorization Lambda error occurred: access_denied: Authorization permission denied",
                     expect.any(AccessDeniedError),
                 );
                 expect(metricsSpyAddMetrics).toHaveBeenCalledWith("authorization_sent", "Count", 0);


### PR DESCRIPTION
## Proposed changes

- Remove references to PAAS environment which was decommissioned a while ago
- Minor refactoring

### What changed

Stubs have been deployed to AWS for a while now

### Why did it change

No longer relevant to have details about PAAS

### Issue tracking

- [OJ-2441](https://govukverify.atlassian.net/browse/OJ-2441)



[OJ-2441]: https://govukverify.atlassian.net/browse/OJ-2441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ