### PR TITLE
OJ-2453: Add `evidence_requested` to session from JAR request

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,36 +57,21 @@ If you have not installed `pre-commit` then please do so [here](https://pre-comm
 
 ## Run Cucumber tests
 
-Below runs by using the AWS stub, with the following defaults:
+Below runs and uses the core stub as default
 
-- DEFAULT_CLIENT_ID="ipv-core-stub-aws-build"
-- ENVIRONMENT=DEV
-- CRI_DEV=common-lambda-dev
+`STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.stubs.account.gov.uk" gradle integration-tests:cucumber
 
-NOTE: Since this is defaulting `CRI_DEV=common-lambda-dev`
-`common-lambda-dev` is configured in https://github.com/govuk-one-login/ipv-config/blob/main/stubs/di-ipv-core-stub/cris-dev.yaml#L42
-and contains keys configured for the common lambda account `di-ipv-cri-common-dev`the `API_GATEWAY_ID_PRIVATE` can be found
-in the output of the common lambda stack being targeted i.e the value of `PreMergeDevOnlyApiId` output.
-
+`Below runs overriding default stub by using the AWS stub`
+STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" DEFAULT_CLIENT_ID=ipv-core-stub-aws-prod gradle integration-tests:cucumber
 `
-STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber
-`
-
-Run in KBV CRI specify `CRI_DEV=kbv-cri-dev` allows the command below to use keys in `ipv-config` pointing to keys in `di-ipv-cri-kbv-dev` for a common lambda stack deploy in that account.
-
-`CRI_DEV=kbv-cri-dev STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber
-
-Run in ADDRESS CRI specify `CRI_DEV=address-cri-dev` allow the command below to use keys in `ipv-config` pointing to keys in `di-ipv-cri-address-dev` for a common lambda stack deploy in that account.
-
-`CRI_DEV=address-cri-dev STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber
 
 You can run against localhost as follows:
 
-`
-STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="http://localhost:8085" gradle integration-tests:cucumber
-`
+Run the either KBV or ADDRESS front-end and ensure the you start the stub as well
 
-NOTE: The common-lambda stack has an extra `/pre-merge-create-auth-code` endpoint which it uses to create an authorization code which it needs as prerequisite to test certain paths, since it is not a CRI itself (since it just a collection of common endpoints used by CRI's).
+`STACK_NAME=di-ipv-cri-common-api-your-stack-name CRI_DEV=kbv-cri-dev ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="http://localhost:8085" gradle integration-tests:cucumber
+
+`
 
 ## Check repo for secrets
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,18 @@ If you have not installed `pre-commit` then please do so [here](https://pre-comm
 
 ## Run Cucumber tests
 
-Below runs and uses the core stub as default
+Below runs and uses the core stub, with the following defaults:
+
+- DEFAULT_CLIENT_ID="ipv-core-stub-aws-build"
+- ENVIRONMENT=DEV
+- CRI_DEV=common-lambda-dev
+
+NOTE: Since this is defaulting `CRI_DEV=common-lambda-dev`
+`common-lambda-dev` is configured in https://github.com/govuk-one-login/ipv-config/blob/main/stubs/di-ipv-core-stub/cris-dev.yaml#L42
+and contains keys configured for the common lambda account `di-ipv-cri-common-dev`the `API_GATEWAY_ID_PRIVATE` can be found
+in the output of the common lambda stack being targeted i.e the value of `PreMergeDevOnlyApiId` output.
+
+`
 
 `STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.stubs.account.gov.uk" gradle integration-tests:cucumber
 
@@ -67,11 +78,31 @@ STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_
 
 You can run against localhost as follows:
 
-Run the either KBV or ADDRESS front-end and ensure the you start the stub as well
+NOTE: Since this is defaulting `CRI_DEV=common-lambda-dev`
+`common-lambda-dev` is configured in https://github.com/govuk-one-login/ipv-config/blob/main/stubs/di-ipv-core-stub/cris-dev.yaml#L42
+and contains keys configured for the common lambda account `di-ipv-cri-common-dev`the `API_GATEWAY_ID_PRIVATE` can be found
+in the output of the common lambda stack being targeted i.e the value of `PreMergeDevOnlyApiId` output.
+
+`
+STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber
+`
+
+Run in KBV CRI specify `CRI_DEV=kbv-cri-dev` allows the command below to use keys in `ipv-config` pointing to keys in `di-ipv-cri-kbv-dev` for a common lambda stack deploy in that account.
+
+`CRI_DEV=kbv-cri-dev STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber
+
+Run in ADDRESS CRI specify `CRI_DEV=address-cri-dev` allow the command below to use keys in `ipv-config` pointing to keys in `di-ipv-cri-address-dev` for a common lambda stack deploy in that account.
+
+`CRI_DEV=address-cri-dev STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber   
+
+You can run against localhost as follows:
 
 `STACK_NAME=di-ipv-cri-common-api-your-stack-name CRI_DEV=kbv-cri-dev ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="http://localhost:8085" gradle integration-tests:cucumber
 
 `
+
+
+NOTE: The common-lambda stack has an extra `/pre-merge-create-auth-code` endpoint which it uses to create an authorization code which it needs as prerequisite to test certain paths, since it is not a CRI itself (since it just a collection of common endpoints used by CRI's).
 
 ## Check repo for secrets
 

--- a/lambdas/README.md
+++ b/lambdas/README.md
@@ -27,3 +27,21 @@ it.only("will only run this test in this file",() => );
 ```
 
 Note that if you dont specify Jest to run just the file with the test, then it will also run the other files in parallel.
+
+## how to deploy
+
+set up your AWS accounts using:
+```
+aws configure sso
+```
+
+Then login via the terminal with he name of the account you wish to access/work on: 
+```
+aws sso login --profile <profile-name>
+```
+
+Then using the following command in the terminal, you can deploy the stack. 
+```
+AWS_PROFILE=<profile-name> ./deploy.sh 
+```
+the deploy does allow for arguments to change the names and identifiers that it will use to execute the set-up.

--- a/lambdas/README.md
+++ b/lambdas/README.md
@@ -8,6 +8,11 @@ The NodeJS lambdas are stores inside the Lambdas directory. Each individual `han
 
 This endpoint takes grant_type, code, client_assertion_type, client_assertion and redirect_uri with content type application/x-www-form-urlencoded and returns Access Token
 
+## How to setup project
+
+To run all tests, run `npm install`. 
+
+
 ## How to run tests
 
 To run all tests, run `npm run test`. This will compile and run all tests in the `/tests` directory.

--- a/lambdas/src/common/security/jwt-verifier.ts
+++ b/lambdas/src/common/security/jwt-verifier.ts
@@ -12,7 +12,7 @@ export enum ClaimNames {
     ISSUED_AT = "iat",
     JWT_ID = "jti",
     REDIRECT_URI = "redirect_uri",
-    SCOPE = "scope",
+    EVIDENCE_REQUESTED = "evidence_requested",
     STATE = "state",
 }
 

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -24,6 +24,7 @@ import initialiseClientConfigMiddleware from "../middlewares/config/initialise-c
 import validateJwtMiddleware from "../middlewares/jwt/validate-jwt-middleware";
 import setGovUkSigningJourneyIdMiddleware from "../middlewares/session/set-gov-uk-signing-journey-id-middleware";
 import { ConfigService } from "../common/config/config-service";
+import { EvidenceRequest } from "../services/evidence_request";
 
 const dynamoDbClient = createClient(AwsClientType.DYNAMO);
 const sqsClient = createClient(AwsClientType.SQS);
@@ -88,6 +89,7 @@ export class SessionLambda implements LambdaInterface {
             redirectUri: jwtPayload["redirect_uri"] as string,
             state: jwtPayload["state"] as string,
             subject: jwtPayload.sub as string,
+            evidenceRequested: jwtPayload["evidence_requested"] as EvidenceRequest,
         };
     }
     private async sendAuditEvent(

--- a/lambdas/src/services/evidence_request.ts
+++ b/lambdas/src/services/evidence_request.ts
@@ -1,0 +1,8 @@
+export type EvidenceRequest = {
+    scoringPolicy?: string;
+    strengthScore?: number;
+    validityScore?: number;
+    verificationScore?: number;
+    activityHistoryScore?: number;
+    identityFraudScore?: number;
+};

--- a/lambdas/src/services/session-request-validator.ts
+++ b/lambdas/src/services/session-request-validator.ts
@@ -4,6 +4,7 @@ import { SessionRequestValidationConfig } from "../types/session-request-validat
 import { ClientConfigKey } from "../types/config-keys";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { SessionValidationError } from "../common/utils/errors";
+import { EvidenceRequest } from "./evidence_request";
 
 export class SessionRequestValidator {
     constructor(
@@ -21,9 +22,15 @@ export class SessionRequestValidator {
             );
         }
 
+        const evidenceRequested = payload["evidence_requested"] as EvidenceRequest;
         const state = payload["state"] as string;
 
-        if (payload.client_id !== requestBodyClientId) {
+        if (evidenceRequested && evidenceRequested?.scoringPolicy !== "gpg45") {
+            throw new SessionValidationError(
+                "Session Validation Exception",
+                "Invalid request: scoringPolicy in evidence_requested does not equal gpg45",
+            );
+        } else if (payload.client_id !== requestBodyClientId) {
             throw new SessionValidationError(
                 "Session Validation Exception",
                 `Invalid request: JWT validation/verification failed: Mismatched client_id in request body (${requestBodyClientId}) & jwt (${payload.client_id})`,

--- a/lambdas/src/services/session-request-validator.ts
+++ b/lambdas/src/services/session-request-validator.ts
@@ -21,7 +21,6 @@ export class SessionRequestValidator {
             );
         }
 
-        // const scope = payload["scope"] as string;
         const state = payload["state"] as string;
 
         if (payload.client_id !== requestBodyClientId) {
@@ -39,9 +38,6 @@ export class SessionRequestValidator {
                 "Session Validation Exception",
                 `Invalid request: JWT validation/verification failed: Redirect uri ${payload.redirect_uri} does not match configuration uri ${expectedRedirectUri}`,
             );
-            //uncomment once core add the scope into claims
-            //} else if (!payload.scope || !scope.toLowerCase().includes("openid")) {
-            //    throw new SessionValidationError("Session Validation Exception", "Invalid scope parameter");
         } else if (!state) {
             throw new SessionValidationError("Session Validation Exception", "Invalid state parameter");
         }
@@ -58,7 +54,6 @@ export class SessionRequestValidator {
                 JwtVerifier.ClaimNames.SUBJECT,
                 JwtVerifier.ClaimNames.NOT_BEFORE,
                 JwtVerifier.ClaimNames.STATE,
-                //JwtVerifier.ClaimNames.SCOPE, //uncomment once core add the scope into claims
             ]),
             new Map([
                 [JwtVerifier.ClaimNames.AUDIENCE, expectedAudience],

--- a/lambdas/src/services/session-service.ts
+++ b/lambdas/src/services/session-service.ts
@@ -110,6 +110,7 @@ export class SessionService {
                 clientSessionId: sessionRequest.clientSessionId,
                 clientIpAddress: sessionRequest.clientIpAddress,
                 attemptCount: 0,
+                evidenceRequest: sessionRequest.evidenceRequested,
             },
         });
         await this.dynamoDbClient.send(putSessionCommand);

--- a/lambdas/src/types/session-request-summary.ts
+++ b/lambdas/src/types/session-request-summary.ts
@@ -1,3 +1,5 @@
+import { EvidenceRequest } from "../services/evidence_request";
+
 export interface SessionRequestSummary {
     clientId: string;
     redirectUri: string;
@@ -6,4 +8,5 @@ export interface SessionRequestSummary {
     clientSessionId: string;
     clientIpAddress: string | null;
     state: string;
+    evidenceRequested?: EvidenceRequest;
 }

--- a/lambdas/tests/unit/services/session-request-validator.test.ts
+++ b/lambdas/tests/unit/services/session-request-validator.test.ts
@@ -99,13 +99,11 @@ describe("session-request-validator.ts", () => {
         });
 
         it("should successfully validate the jwt", async () => {
-            const scope = "openid";
             const state = "state";
             jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
                 Promise.resolve({
                     client_id: "request-client-id",
                     redirect_uri: "redirect-uri",
-                    scope: scope,
                     state: state,
                     shared_claims: personIdentity,
                 } as JWTPayload),
@@ -117,7 +115,6 @@ describe("session-request-validator.ts", () => {
             expect(response).toEqual({
                 client_id: "request-client-id",
                 redirect_uri: "redirect-uri",
-                scope: scope,
                 state: state,
                 shared_claims: personIdentity,
             });
@@ -146,7 +143,6 @@ describe("session-request-validator.ts", () => {
             const jwtPayload = {
                 client_id: client_id,
                 redirect_uri: "redirect-uri",
-                scope: "openid",
                 state: "state",
                 shared_claims: personIdentity,
             } as JWTPayload;
@@ -224,41 +220,14 @@ describe("session-request-validator.ts", () => {
 
             await expect(async () => sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).resolves;
         });
-
-        xit("should fail to validate the jwt if scope is missing", async () => {
-            const client_id = "request-client-id";
-            const redirect_uri = "redirect-uri";
-            const state = "state";
-
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                Promise.resolve({
-                    client_id: client_id,
-                    redirect_uri: redirect_uri,
-                    state: state,
-                    shared_claims: personIdentity,
-                } as JWTPayload),
-            );
-
-            await expect(async () =>
-                sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id),
-            ).rejects.toThrow(
-                expect.objectContaining({
-                    message: "Session Validation Exception",
-                    details: "Invalid scope parameter",
-                }),
-            );
-        });
-
         it("should fail to validate the jwt if state is missing", async () => {
             const client_id = "request-client-id";
             const redirect_uri = "redirect-uri";
-            const scope = "openid";
 
             jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
                 Promise.resolve({
                     client_id: client_id,
                     redirect_uri: redirect_uri,
-                    scope: scope,
                     shared_claims: personIdentity,
                 } as JWTPayload),
             );


### PR DESCRIPTION
## Proposed changes

### What and why did it change
Added `evidence_requested` details into the session table because ipv-core now sends `evidence_requested` within the signed JAR payload. This has superseded the `scope` value that was provided however this was not used in common-lambda.

### Issue tracking
- [OJ-2453](https://govukverify.atlassian.net/browse/OJ-2453)


[OJ-2453]: https://govukverify.atlassian.net/browse/OJ-2453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ