### PR TITLE
OJ-2453 validate strength score

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -582,6 +582,7 @@ Resources:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-sessionTS"
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          CRI_IDENTIFIER: !Sub "${CriIdentifier}"
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess


### PR DESCRIPTION
## Proposed changes

### What changed
Updated the session-request-validator to check if the strengthScore is 2 within the `evidence_requested` field for the NINO CRI.

### Issue tracking
- [OJ-2453](https://govukverify.atlassian.net/browse/OJ-2453)


[OJ-2453]: https://govukverify.atlassian.net/browse/OJ-2453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ