### PR TITLE
OJ-2524: refactor evidence request (PART 1)

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -108,20 +108,45 @@ Globals:
         SQS_AUDIT_EVENT_PREFIX: !Ref AuditEventNamePrefix
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
         DT_CONNECTION_AUTH_TOKEN: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
         DT_CONNECTION_BASE_URL: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
         DT_CLUSTER_ID: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
         DT_LOG_COLLECTION_AUTH_TOKEN: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
         DT_TENANT: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
 
 Mappings:
@@ -426,6 +451,10 @@ Mappings:
       staging: "https://review-hc.staging.account.gov.uk"
       integration: "https://review-hc.integration.account.gov.uk"
       production: "https://review-hc.account.gov.uk"
+  
+  EvidenceRequestedMapping:
+    di-ipv-cri-check-hmrc-api:
+      strengthScore: 2
 
 Resources:
   ##############################
@@ -442,8 +471,13 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-AuditEventConsumerFunction"
       Layers:
         - !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-audit-event-consumer"
@@ -510,8 +544,13 @@ Resources:
       Runtime: java11
       Layers:
         - !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-session"
@@ -576,8 +615,13 @@ Resources:
       Runtime: nodejs18.x
       Layers:
         - !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-sessionTS"
@@ -607,6 +651,7 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiable-credential/issuer"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CriIdentifier}/strengthScore"
         - Statement:
             - Sid: auditEventQueueKmsEncryptionKeyPermission
               Effect: Allow
@@ -648,8 +693,13 @@ Resources:
       Runtime: java11
       Layers:
         - !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-authorization"
@@ -688,8 +738,13 @@ Resources:
       Runtime: nodejs18.x
       Layers:
         - !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-authorizationTS"
@@ -750,8 +805,13 @@ Resources:
       Runtime: java11
       Layers:
         - !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-access-token"
@@ -785,8 +845,13 @@ Resources:
       Runtime: nodejs18.x
       Layers:
         - !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-access-token-2"
@@ -945,6 +1010,14 @@ Resources:
       Type: String
       Value: !FindInMap [SessionTtlMapping, Environment, !Ref "Environment"]
       Description: default time to live for a session item (seconds)
+
+  EvidenceRequestedStrengthScoreParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${CriIdentifier}/strengthScore"
+      Type: String
+      Value: !FindInMap [EvidenceRequestedMapping, !Ref CriIdentifier, "strengthScore"]
+      Description: The CRI supported strength score
 
   IPVCoreStubAwsProdAuthenticationAlgParameter:
     Condition: IsStubEnvironment
@@ -1374,8 +1447,13 @@ Resources:
       Runtime: nodejs18.x
       Layers:
         - !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-create-auth-code"
@@ -1456,7 +1534,6 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PreMergeDevOnlyApi}-private-AccessLogs
       RetentionInDays: 7
-
 
   ##################################################################################################
   # ipv-core-stub-aws-prod_3rdparty clientId configuration

--- a/lambdas/src/types/config-keys.ts
+++ b/lambdas/src/types/config-keys.ts
@@ -13,3 +13,12 @@ export enum ClientConfigKey {
     JWT_REDIRECT_URI = "redirectUri",
     JWT_SIGNING_ALGORITHM = "authenticationAlg",
 }
+
+export enum ConfigKey {
+    STRENGTH_SCORE = "strengthScore",
+}
+
+export interface AbsoluteParameterPath {
+    prefix: string;
+    suffix: string;
+}

--- a/lambdas/src/types/evidence-requested-config.ts
+++ b/lambdas/src/types/evidence-requested-config.ts
@@ -1,0 +1,8 @@
+export interface EvidenceRequestConfig {
+    scoringPolicy: string;
+    strengthScore: number;
+    validityScore: number;
+    verificationScore: number;
+    activityHistoryScore: number;
+    identityFraudScore: number;
+}


### PR DESCRIPTION
## Proposed changes
Related to: https://govukverify.atlassian.net/browse/OJ-2524

Do evidence mapping in common-lambda template instead of hard-coding in session validator

### Why did it change

It would make it easier to add evidence mapping for other CRI's when needed

The mapping for evidence request moved from code to common lambda
template. Here each CRI using common lambda would provide it's
strengthScore value through a mapping i.e.

```
  EvidenceRequestedMapping:
    di-ipv-cri-check-hmrc-api:
      strengthScore: 2
    di-ipv-cri-dl-api:
      strengthScore: 3
```
then the value can be retrieved through the corresponding parameter

```
  EvidenceRequestedStrengthScoreParameter:
    Type: AWS::SSM::Parameter
    Properties:
      Name: !Sub "/${CriIdentifier}/strengthScore"
      Type: String
      Value: !FindInMap [ EvidenceRequestedMapping, !Ref CriIdentifier, strengthScore ]
      Description: The CRI supported strength score
```

### Issue tracking


- [OJ-2524](https://govukverify.atlassian.net/browse/OJ-2524)


[OJ-2524]: https://govukverify.atlassian.net/browse/OJ-2524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ