### PR TITLE
OJ-2524: add context to start event

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -669,7 +669,7 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiable-credential/issuer"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CriIdentifier}/strengthScore"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/${CriIdentifier}/strengthScore"
         - Statement:
             - Sid: auditEventQueueKmsEncryptionKeyPermission
               Effect: Allow
@@ -1032,7 +1032,7 @@ Resources:
   EvidenceRequestedStrengthScoreParameter:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub "/${CriIdentifier}/strengthScore"
+      Name: !Sub "/${AWS::StackName}/${CriIdentifier}/strengthScore"
       Type: String
       Value: !FindInMap [EvidenceRequestedMapping, !Ref CriIdentifier, "strengthScore"]
       Description: The CRI supported strength score

--- a/lambdas/src/middlewares/config/initialise-client-config-middleware.ts
+++ b/lambdas/src/middlewares/config/initialise-client-config-middleware.ts
@@ -1,13 +1,13 @@
 import { MiddlewareObj, Request } from "@middy/core";
 import { ConfigService } from "../../common/config/config-service";
-import { AbsoluteParameterPath, ClientConfigKey } from "../../types/config-keys";
+import { ParameterPath, ClientConfigKey } from "../../types/config-keys";
 
 const defaults = {};
 
 const initialiseClientConfigMiddleware = (opts: {
     configService: ConfigService;
     client_config_keys: ClientConfigKey[];
-    client_absolute_paths?: [AbsoluteParameterPath];
+    client_absolute_paths?: [ParameterPath];
 }): MiddlewareObj => {
     const options = { ...defaults, ...opts };
 
@@ -20,7 +20,7 @@ const initialiseClientConfigMiddleware = (opts: {
 
             if (options.client_absolute_paths) {
                 for (const param of options.client_absolute_paths) {
-                    await options.configService.initConfigUsingAbsolutePath(clientId, param.prefix, param.suffix);
+                    await options.configService.initConfigWithCriIdentifierInPath(clientId, param.prefix, param.suffix);
                 }
             }
         }

--- a/lambdas/src/types/config-keys.ts
+++ b/lambdas/src/types/config-keys.ts
@@ -18,7 +18,7 @@ export enum ConfigKey {
     STRENGTH_SCORE = "strengthScore",
 }
 
-export interface AbsoluteParameterPath {
+export interface ParameterPath {
     prefix: string;
     suffix: string;
 }

--- a/lambdas/tests/unit/common/config/config-service.test.ts
+++ b/lambdas/tests/unit/common/config/config-service.test.ts
@@ -147,7 +147,7 @@ describe("ConfigService", () => {
                 "/di-ipv-cri-check-hmrc-api/strengthScore": "2",
             });
 
-            await configService.initConfigUsingAbsolutePath(
+            await configService.initConfigWithCriIdentifierInPath(
                 "test",
                 "di-ipv-cri-check-hmrc-api",
                 ConfigKey.STRENGTH_SCORE,
@@ -155,7 +155,7 @@ describe("ConfigService", () => {
 
             expect(ssmProvider.getParametersByName).toBeCalledWith(
                 {
-                    "/di-ipv-cri-check-hmrc-api/strengthScore": {},
+                    "/di-ipv-cri-common-lambdas/di-ipv-cri-check-hmrc-api/strengthScore": {},
                 },
                 expect.objectContaining({
                     maxAge: 300,
@@ -170,7 +170,7 @@ describe("ConfigService", () => {
             });
 
             expect(
-                configService.initConfigUsingAbsolutePath(
+                configService.initConfigWithCriIdentifierInPath(
                     "test",
                     "di-ipv-cri-check-hmrc-api",
                     ConfigKey.STRENGTH_SCORE,
@@ -179,7 +179,7 @@ describe("ConfigService", () => {
 
             expect(ssmProvider.getParametersByName).toBeCalledWith(
                 {
-                    "/di-ipv-cri-check-hmrc-api/strengthScore": {},
+                    "/di-ipv-cri-common-lambdas/di-ipv-cri-check-hmrc-api/strengthScore": {},
                 },
                 expect.objectContaining({
                     maxAge: 300,


### PR DESCRIPTION
## Proposed changes

In addition to the work done as part of  to include information useful to the Fraud and Analytics teams, an extensions.evidence.context field should be included in the IPV_HMRC_RECORD_CHECK_CRI_START event to indicate whether the NINO CRI was initiated for a identity check

Implementation of a record_check in the start event is out of scope for this ticket

### What changed

Added context to START_EVENT



- [OJ-2524(https://govukverify.atlassian.net/browse/OJ-2524)
