### PR TITLE
LIME-1079 - Saving Nino from shared_claims to personIdentityTable for…

### DIFF
--- a/lambdas/src/services/person-identity-service.ts
+++ b/lambdas/src/services/person-identity-service.ts
@@ -1,12 +1,13 @@
 import { DynamoDBDocument, PutCommand } from "@aws-sdk/lib-dynamodb";
 import { ConfigService } from "../common/config/config-service";
 import { CommonConfigKey } from "../types/config-keys";
-import { Address, BirthDate, Name, PersonIdentity } from "../types/person-identity";
+import { Address, BirthDate, Name, PersonIdentity, SocialSecurityRecord } from "../types/person-identity";
 import {
     PersonIdentityAddress,
     PersonIdentityDateOfBirth,
     PersonIdentityItem,
     PersonIdentityName,
+    PersonIdentitySocialSecurityRecord,
 } from "../types/person-identity-item";
 
 export class PersonIdentityService {
@@ -40,6 +41,7 @@ export class PersonIdentityService {
             birthDates: this.mapBirthDates(sharedClaims.birthDate),
             expiryDate: sessionExpirationEpoch,
             names: this.mapNames(sharedClaims.name),
+            socialSecurityRecord: this.mapNino(sharedClaims.socialSecurityRecord),
         };
     }
     private mapAddresses(addresses: Address[]): PersonIdentityAddress[] {
@@ -71,5 +73,8 @@ export class PersonIdentityService {
                 value: namePart.value,
             })),
         }));
+    }
+    private mapNino(socialSecurityRecord: SocialSecurityRecord[]): PersonIdentitySocialSecurityRecord[] {
+        return socialSecurityRecord?.map((record) => ({ personalNumber: record.personalNumber }));
     }
 }

--- a/lambdas/src/services/person-identity-service.ts
+++ b/lambdas/src/services/person-identity-service.ts
@@ -74,7 +74,7 @@ export class PersonIdentityService {
             })),
         }));
     }
-    private mapNino(socialSecurityRecord: SocialSecurityRecord[]): PersonIdentitySocialSecurityRecord[] {
-        return socialSecurityRecord?.map((record) => ({ personalNumber: record.personalNumber }));
+    private mapNino(socialSecurityRecord?: SocialSecurityRecord[]): PersonIdentitySocialSecurityRecord[] | undefined {
+        return socialSecurityRecord?.map((record) => ({ personalNumber: record?.personalNumber }));
     }
 }

--- a/lambdas/src/types/person-identity-item.ts
+++ b/lambdas/src/types/person-identity-item.ts
@@ -39,5 +39,5 @@ export interface PersonIdentityItem {
     names: PersonIdentityName[];
     birthDates: PersonIdentityDateOfBirth[];
     expiryDate: number;
-    socialSecurityRecord: PersonIdentitySocialSecurityRecord[];
+    socialSecurityRecord?: PersonIdentitySocialSecurityRecord[];
 }

--- a/lambdas/src/types/person-identity-item.ts
+++ b/lambdas/src/types/person-identity-item.ts
@@ -1,3 +1,7 @@
+export interface PersonIdentitySocialSecurityRecord {
+    personalNumber: string;
+}
+
 export interface PersonIdentityNamePart {
     type: string;
     value: string;
@@ -35,4 +39,5 @@ export interface PersonIdentityItem {
     names: PersonIdentityName[];
     birthDates: PersonIdentityDateOfBirth[];
     expiryDate: number;
+    socialSecurityRecord: PersonIdentitySocialSecurityRecord[];
 }

--- a/lambdas/src/types/person-identity.ts
+++ b/lambdas/src/types/person-identity.ts
@@ -1,3 +1,7 @@
+export interface SocialSecurityRecord {
+    personalNumber?: string;
+}
+
 export interface NamePart {
     type: string;
     value: string;
@@ -30,6 +34,7 @@ export interface Address {
 }
 
 export interface PersonIdentity {
+    socialSecurityRecord?: SocialSecurityRecord[];
     name: Name[];
     birthDate: BirthDate[];
     address: Address[];

--- a/lambdas/src/types/person-identity.ts
+++ b/lambdas/src/types/person-identity.ts
@@ -1,5 +1,5 @@
 export interface SocialSecurityRecord {
-    personalNumber?: string;
+    personalNumber: string;
 }
 
 export interface NamePart {

--- a/lambdas/tests/unit/services/person-identity-service.test.ts
+++ b/lambdas/tests/unit/services/person-identity-service.test.ts
@@ -44,6 +44,11 @@ describe("PersonIdentityService", () => {
     const sessionId = "test-session-id";
 
     const mockPerson: PersonIdentity = {
+        socialSecurityRecord: [
+            {
+                personalNumber: "AA000003D",
+            },
+        ],
         name: [
             {
                 nameParts: [
@@ -111,12 +116,14 @@ describe("PersonIdentityService", () => {
                 birthDates: mockPerson.birthDate,
                 expiryDate: 1675382400,
                 names: mockPerson.name,
+                socialSecurityRecord: mockPerson.socialSecurityRecord,
             },
         });
     });
 
     it("should avoid formatting blank identities", async () => {
         const newMockPerson: PersonIdentity = {
+            socialSecurityRecord: [],
             name: [],
             birthDate: [],
             address: [],
@@ -131,6 +138,7 @@ describe("PersonIdentityService", () => {
                 birthDates: [],
                 expiryDate: 1675382400,
                 names: [],
+                socialSecurityRecord: [],
             },
         });
     });


### PR DESCRIPTION
### What changed
 - Storing nino value in sharedClaims sent by IPV Core
 - Mapping nino value in sharedClaims to personIdentityTable
 - Save Nino to personIdentityTable