### PR TITLE
LIME-1161 Correct TTL in person-identity-service.ts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -126,5 +130,5 @@
     }
   ],
   "results": {},
-  "generated_at": "2024-01-12T09:54:36Z"
+  "generated_at": "2024-06-10T15:54:02Z"
 }

--- a/lambdas/src/services/person-identity-service.ts
+++ b/lambdas/src/services/person-identity-service.ts
@@ -17,11 +17,8 @@ export class PersonIdentityService {
     ) {}
 
     public async savePersonIdentity(sharedClaims: PersonIdentity, sessionId: string): Promise<string> {
-        const personIdentityItem = this.createPersonIdentityItem(
-            sharedClaims,
-            sessionId,
-            +this.configService.getConfigEntry(CommonConfigKey.SESSION_TTL),
-        );
+        const sessionExpirationEpoch = this.configService.getSessionExpirationEpoch();
+        const personIdentityItem = this.createPersonIdentityItem(sharedClaims, sessionId, sessionExpirationEpoch);
 
         const putSessionCommand = new PutCommand({
             TableName: this.configService.getConfigEntry(CommonConfigKey.PERSON_IDENTITY_TABLE_NAME),

--- a/lambdas/tests/unit/services/person-identity-service.test.ts
+++ b/lambdas/tests/unit/services/person-identity-service.test.ts
@@ -36,8 +36,8 @@ describe("PersonIdentityService", () => {
     jest.spyOn(mockConfigService.prototype, "getConfigEntry").mockImplementation((key: CommonConfigKey) => {
         if (key === CommonConfigKey.PERSON_IDENTITY_TABLE_NAME) {
             return "PersonIdentityTable";
-        } else {
-            return "1675382400";
+        } else if (key === CommonConfigKey.SESSION_TTL) {
+            return 7200;
         }
     });
 
@@ -106,6 +106,7 @@ describe("PersonIdentityService", () => {
     });
 
     it("should correctly format personal identity information", async () => {
+        const expectedExpiry: number = Math.floor((Date.now() + 7200 * 1000) / 1000);
         await personIdentityService.savePersonIdentity(mockPerson, sessionId);
 
         expect(mockPutCommand).toHaveBeenCalledWith({
@@ -114,7 +115,7 @@ describe("PersonIdentityService", () => {
                 sessionId: "test-session-id",
                 addresses: mockPerson.address,
                 birthDates: mockPerson.birthDate,
-                expiryDate: 1675382400,
+                expiryDate: expectedExpiry,
                 names: mockPerson.name,
                 socialSecurityRecord: mockPerson.socialSecurityRecord,
             },
@@ -122,6 +123,7 @@ describe("PersonIdentityService", () => {
     });
 
     it("should avoid formatting blank identities", async () => {
+        const expectedExpiry: number = Math.floor((Date.now() + 7200 * 1000) / 1000);
         const newMockPerson: PersonIdentity = {
             socialSecurityRecord: [],
             name: [],
@@ -136,7 +138,7 @@ describe("PersonIdentityService", () => {
                 sessionId: "test-session-id",
                 addresses: [],
                 birthDates: [],
-                expiryDate: 1675382400,
+                expiryDate: expectedExpiry,
                 names: [],
                 socialSecurityRecord: [],
             },


### PR DESCRIPTION
## Proposed changes

### What changed

Correct TTL in person-identity-service.ts

### Why did it change

TTL was inadvertently set to the raw value of the expiry window (7200/2hrs), instead of the calculated expiry time.

### Issue tracking

- [LIME-1161](https://govukverify.atlassian.net/browse/LIME-1161)

[LIME-1161]: https://govukverify.atlassian.net/browse/LIME-1161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ