### PR TITLE
BAU: Enable CSLS for check-hmrc-api

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -66,9 +66,7 @@ Conditions:
           - "none"
   IsCSLSDisabled: !And
     - !Not
-      - !Or
-        - !Equals [!Ref CriIdentifier, "di-ipv-cri-check-hmrc-api"]
-        - !Equals [!Ref CriIdentifier, "di-ipv-cri-kbv-hmrc-api"]
+      - !Equals [!Ref CriIdentifier, "di-ipv-cri-kbv-hmrc-api"]
     - !Not
       - !Equals [!Ref Environment, "dev"]
 


### PR DESCRIPTION
## Proposed changes

### What changed
CSLS was disabled for check-hmrc-cri-api so there was no common lambda logs going to Splunk. 