### PR TITLE
OJ-2641: Support multiple scores for cri

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: "AWS::Serverless-2016-10-31"
+Transform: [AWS::LanguageExtensions, AWS::Serverless-2016-10-31]
 Description: "Digital Identity IPV CRI common API"
 
 Parameters:
@@ -472,7 +472,6 @@ Mappings:
     di-ipv-cri-kbv-hmrc-api:
       strengthScore: 2
 
-
 Resources:
 
   #########################
@@ -606,6 +605,7 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiable-credential/issuer"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/${CriIdentifier}/strengthScore"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/${CriIdentifier}/evidenceProperties"
         - Statement:
             - Sid: auditEventQueueKmsEncryptionKeyPermission
               Effect: Allow
@@ -972,6 +972,19 @@ Resources:
       Type: String
       Value: !FindInMap [EvidenceRequestedMapping, !Ref CriIdentifier, "strengthScore"]
       Description: The CRI supported strength score
+
+  KBVEvidenceProperties:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/${CriIdentifier}/evidenceProperties"
+      Type: String
+      Value: 
+        Fn::ToJsonString: 
+          "strengthScore": "2"
+          "verificationScore": 
+            - "1"
+            - "2"
+      Description: evidence properties the CRI accepts
 
   IPVCoreStubAwsProdAuthenticationAlgParameter:
     Condition: IsStubEnvironment

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: [AWS::LanguageExtensions, AWS::Serverless-2016-10-31]
+Transform: "AWS::Serverless-2016-10-31"
 Description: "Digital Identity IPV CRI common API"
 
 Parameters:
@@ -453,24 +453,6 @@ Mappings:
       staging: "https://review-hc.staging.account.gov.uk"
       integration: "https://review-hc.integration.account.gov.uk"
       production: "https://review-hc.account.gov.uk"
-  
-  EvidenceRequestedMapping:
-    di-ipv-cri-check-hmrc-api:
-      strengthScore: 2
-    di-ipv-cri-address-api:
-      strengthScore: 0
-    di-ipv-cri-toy-api:
-      strengthScore: 0
-    di-ipv-cri-fraud-api:
-      strengthScore: 2
-    di-ipv-cri-kbv-api:
-      strengthScore: 2
-    di-ipv-cri-dl-api:
-      strengthScore: 3
-    di-ipv-cri-passport-api:
-      strengthScore: 4
-    di-ipv-cri-kbv-hmrc-api:
-      strengthScore: 2
 
 Resources:
 
@@ -604,8 +586,7 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/PersonIdentityTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiable-credential/issuer"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/${CriIdentifier}/strengthScore"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/${CriIdentifier}/evidenceProperties"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CriIdentifier}/evidence-properties"
         - Statement:
             - Sid: auditEventQueueKmsEncryptionKeyPermission
               Effect: Allow
@@ -964,27 +945,6 @@ Resources:
       Type: String
       Value: !FindInMap [SessionTtlMapping, Environment, !Ref "Environment"]
       Description: default time to live for a session item (seconds)
-
-  EvidenceRequestedStrengthScoreParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/${CriIdentifier}/strengthScore"
-      Type: String
-      Value: !FindInMap [EvidenceRequestedMapping, !Ref CriIdentifier, "strengthScore"]
-      Description: The CRI supported strength score
-
-  KBVEvidenceProperties:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/${CriIdentifier}/evidenceProperties"
-      Type: String
-      Value: 
-        Fn::ToJsonString: 
-          "strengthScore": "2"
-          "verificationScore": 
-            - "1"
-            - "2"
-      Description: evidence properties the CRI accepts
 
   IPVCoreStubAwsProdAuthenticationAlgParameter:
     Condition: IsStubEnvironment

--- a/lambdas/src/common/config/config-service.ts
+++ b/lambdas/src/common/config/config-service.ts
@@ -42,6 +42,7 @@ export class ConfigService {
         const ssmParameters = await this.getCriIdentifierParameters([`/${parameterPrefix}/${paramNameSuffix}`]);
         if (ssmParameters.length === 0) {
             logger.info(`Invalid parameter beginning with ${parameterPrefix} encountered`);
+            return;
         }
         await this.setParametersByAbsolutePath(ssmParameters, clientId);
     }
@@ -49,8 +50,6 @@ export class ConfigService {
     private async setParametersByAbsolutePath(ssmParameters: Parameter[], identifier: string) {
         const clientConfigEntries: Map<string, string> =
             this.clientConfigurations.get(identifier) || new Map<string, string>();
-
-        if (ssmParameters.length === 0) return;
 
         ssmParameters.forEach(({ Name, Value }) => {
             clientConfigEntries.set(...this.validateNameSuffix(Name, Value));

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -169,10 +169,7 @@ export const lambdaHandler = middy(handlerClass.handler.bind(handlerClass))
                 ClientConfigKey.JWT_REDIRECT_URI,
                 ClientConfigKey.JWT_SIGNING_ALGORITHM,
             ],
-            client_absolute_paths: [
-                { prefix: criIdentifier, suffix: ConfigKey.STRENGTH_SCORE },
-                { prefix: criIdentifier, suffix: ConfigKey.CRI_EVIDENCE_PROPERTIES },
-            ],
+            client_absolute_paths: [{ prefix: criIdentifier, suffix: ConfigKey.CRI_EVIDENCE_PROPERTIES }],
         }),
     )
     .use(validateJwtMiddleware(logger, { configService: configService, jwtValidatorFactory: jwtValidatorFactory }))

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -169,7 +169,10 @@ export const lambdaHandler = middy(handlerClass.handler.bind(handlerClass))
                 ClientConfigKey.JWT_REDIRECT_URI,
                 ClientConfigKey.JWT_SIGNING_ALGORITHM,
             ],
-            client_absolute_paths: [{ prefix: criIdentifier, suffix: ConfigKey.STRENGTH_SCORE }],
+            client_absolute_paths: [
+                { prefix: criIdentifier, suffix: ConfigKey.STRENGTH_SCORE },
+                { prefix: criIdentifier, suffix: ConfigKey.CRI_EVIDENCE_PROPERTIES },
+            ],
         }),
     )
     .use(validateJwtMiddleware(logger, { configService: configService, jwtValidatorFactory: jwtValidatorFactory }))

--- a/lambdas/src/middlewares/config/initialise-client-config-middleware.ts
+++ b/lambdas/src/middlewares/config/initialise-client-config-middleware.ts
@@ -7,7 +7,7 @@ const defaults = {};
 const initialiseClientConfigMiddleware = (opts: {
     configService: ConfigService;
     client_config_keys: ClientConfigKey[];
-    client_absolute_paths?: [ParameterPath];
+    client_absolute_paths?: ParameterPath[];
 }): MiddlewareObj => {
     const options = { ...defaults, ...opts };
 

--- a/lambdas/src/services/cri_evidence_properties.ts
+++ b/lambdas/src/services/cri_evidence_properties.ts
@@ -1,0 +1,8 @@
+export type CRIEvidenceProperties = {
+    scoringPolicy?: string;
+    strengthScore?: number;
+    validityScore?: number;
+    verificationScore?: number[];
+    activityHistoryScore?: number;
+    identityFraudScore?: number;
+};

--- a/lambdas/src/services/session-request-validator.ts
+++ b/lambdas/src/services/session-request-validator.ts
@@ -33,7 +33,11 @@ export class SessionRequestValidator {
                 "Invalid request: scoringPolicy in evidence_requested does not equal gpg45",
             );
         }
-        if (evidenceRequested && evidenceRequested?.strengthScore !== configuredStrengthScore) {
+        if (
+            evidenceRequested?.strengthScore &&
+            configuredStrengthScore &&
+            evidenceRequested.strengthScore !== configuredStrengthScore
+        ) {
             throw new SessionValidationError(
                 "Session Validation Exception",
                 `Invalid request: strengthScore in evidence_requested does not equal ${configuredStrengthScore}`,

--- a/lambdas/src/services/session-request-validator.ts
+++ b/lambdas/src/services/session-request-validator.ts
@@ -33,11 +33,7 @@ export class SessionRequestValidator {
                 "Invalid request: scoringPolicy in evidence_requested does not equal gpg45",
             );
         }
-        if (
-            evidenceRequested?.strengthScore &&
-            configuredStrengthScore &&
-            evidenceRequested.strengthScore !== configuredStrengthScore
-        ) {
+        if (this.validateStrengthScore(configuredStrengthScore, evidenceRequested)) {
             throw new SessionValidationError(
                 "Session Validation Exception",
                 `Invalid request: strengthScore in evidence_requested does not equal ${configuredStrengthScore}`,
@@ -68,9 +64,16 @@ export class SessionRequestValidator {
 
         return payload;
     }
+    private validateStrengthScore(configuredStrengthScore: number, evidenceRequested: EvidenceRequest) {
+        return (
+            configuredStrengthScore &&
+            evidenceRequested?.strengthScore &&
+            evidenceRequested.strengthScore !== configuredStrengthScore
+        );
+    }
+
     private validateVerificationScore(evidenceRequested: EvidenceRequest) {
         return (
-            evidenceRequested &&
             evidenceRequested?.verificationScore &&
             this.criEvidenceProperties?.verificationScore &&
             !this.criEvidenceProperties.verificationScore

--- a/lambdas/src/types/config-keys.ts
+++ b/lambdas/src/types/config-keys.ts
@@ -16,6 +16,7 @@ export enum ClientConfigKey {
 
 export enum ConfigKey {
     STRENGTH_SCORE = "strengthScore",
+    CRI_EVIDENCE_PROPERTIES = "evidenceProperties",
 }
 
 export interface ParameterPath {

--- a/lambdas/src/types/config-keys.ts
+++ b/lambdas/src/types/config-keys.ts
@@ -16,7 +16,7 @@ export enum ClientConfigKey {
 
 export enum ConfigKey {
     STRENGTH_SCORE = "strengthScore",
-    CRI_EVIDENCE_PROPERTIES = "evidenceProperties",
+    CRI_EVIDENCE_PROPERTIES = "evidence-properties",
 }
 
 export interface ParameterPath {

--- a/lambdas/src/types/config-keys.ts
+++ b/lambdas/src/types/config-keys.ts
@@ -15,7 +15,6 @@ export enum ClientConfigKey {
 }
 
 export enum ConfigKey {
-    STRENGTH_SCORE = "strengthScore",
     CRI_EVIDENCE_PROPERTIES = "evidence-properties",
 }
 

--- a/lambdas/src/types/evidence-requested-config.ts
+++ b/lambdas/src/types/evidence-requested-config.ts
@@ -1,8 +1,0 @@
-export interface EvidenceRequestConfig {
-    scoringPolicy: string;
-    strengthScore: number;
-    validityScore: number;
-    verificationScore: number;
-    activityHistoryScore: number;
-    identityFraudScore: number;
-}

--- a/lambdas/tests/unit/common/config/config-service.test.ts
+++ b/lambdas/tests/unit/common/config/config-service.test.ts
@@ -150,12 +150,12 @@ describe("ConfigService", () => {
             await configService.initConfigWithCriIdentifierInPath(
                 "test",
                 "di-ipv-cri-check-hmrc-api",
-                ConfigKey.STRENGTH_SCORE,
+                ConfigKey.CRI_EVIDENCE_PROPERTIES,
             );
 
             expect(ssmProvider.getParametersByName).toBeCalledWith(
                 {
-                    "/di-ipv-cri-common-lambdas/di-ipv-cri-check-hmrc-api/strengthScore": {},
+                    "/di-ipv-cri-check-hmrc-api/evidence-properties": {},
                 },
                 expect.objectContaining({
                     maxAge: 300,
@@ -169,17 +169,15 @@ describe("ConfigService", () => {
                 _errors: [],
             });
 
-            expect(
-                configService.initConfigWithCriIdentifierInPath(
-                    "test",
-                    "di-ipv-cri-check-hmrc-api",
-                    ConfigKey.STRENGTH_SCORE,
-                ),
-            ).rejects.toThrowError("Invalid parameter beginning with di-ipv-cri-check-hmrc-api encountered");
+            configService.initConfigWithCriIdentifierInPath(
+                "test",
+                "di-ipv-cri-check-hmrc-api",
+                ConfigKey.CRI_EVIDENCE_PROPERTIES,
+            );
 
             expect(ssmProvider.getParametersByName).toBeCalledWith(
                 {
-                    "/di-ipv-cri-common-lambdas/di-ipv-cri-check-hmrc-api/strengthScore": {},
+                    "/di-ipv-cri-check-hmrc-api/evidence-properties": {},
                 },
                 expect.objectContaining({
                     maxAge: 300,

--- a/lambdas/tests/unit/handlers/session-handler.test.ts
+++ b/lambdas/tests/unit/handlers/session-handler.test.ts
@@ -444,7 +444,6 @@ describe("SessionLambda", () => {
                             ClientConfigKey.JWT_SIGNING_ALGORITHM,
                         ],
                         client_absolute_paths: [
-                            { prefix: previousCriIdentifier, suffix: ConfigKey.STRENGTH_SCORE },
                             { prefix: previousCriIdentifier, suffix: ConfigKey.CRI_EVIDENCE_PROPERTIES },
                         ],
                     }),
@@ -591,7 +590,6 @@ describe("SessionLambda", () => {
                             ClientConfigKey.JWT_SIGNING_ALGORITHM,
                         ],
                         client_absolute_paths: [
-                            { prefix: previousCriIdentifier, suffix: ConfigKey.STRENGTH_SCORE },
                             { prefix: previousCriIdentifier, suffix: ConfigKey.CRI_EVIDENCE_PROPERTIES },
                         ],
                     }),

--- a/lambdas/tests/unit/handlers/session-handler.test.ts
+++ b/lambdas/tests/unit/handlers/session-handler.test.ts
@@ -443,7 +443,10 @@ describe("SessionLambda", () => {
                             ClientConfigKey.JWT_REDIRECT_URI,
                             ClientConfigKey.JWT_SIGNING_ALGORITHM,
                         ],
-                        client_absolute_paths: [{ prefix: previousCriIdentifier, suffix: ConfigKey.STRENGTH_SCORE }],
+                        client_absolute_paths: [
+                            { prefix: previousCriIdentifier, suffix: ConfigKey.STRENGTH_SCORE },
+                            { prefix: previousCriIdentifier, suffix: ConfigKey.CRI_EVIDENCE_PROPERTIES },
+                        ],
                     }),
                 )
                 .use(
@@ -587,7 +590,10 @@ describe("SessionLambda", () => {
                             ClientConfigKey.JWT_REDIRECT_URI,
                             ClientConfigKey.JWT_SIGNING_ALGORITHM,
                         ],
-                        client_absolute_paths: [{ prefix: previousCriIdentifier, suffix: ConfigKey.STRENGTH_SCORE }],
+                        client_absolute_paths: [
+                            { prefix: previousCriIdentifier, suffix: ConfigKey.STRENGTH_SCORE },
+                            { prefix: previousCriIdentifier, suffix: ConfigKey.CRI_EVIDENCE_PROPERTIES },
+                        ],
                     }),
                 )
                 .use(

--- a/lambdas/tests/unit/services/session-request-validator.test.ts
+++ b/lambdas/tests/unit/services/session-request-validator.test.ts
@@ -311,7 +311,6 @@ describe("session-request-validator.ts", () => {
             sessionRequestValidator = new SessionRequestValidator(
                 sessionRequestValidationConfig,
                 jwtVerifier.prototype,
-                undefined,
                 { verificationScore: [1, 2] } as CRIEvidenceProperties,
             );
         });
@@ -344,7 +343,7 @@ describe("session-request-validator.ts", () => {
             process.env.CRI_IDENTIFIER = previousCriIdentifier;
         });
 
-        it("should pass when verifcationScore is 2 and cri is di-ipv-cri-kbv-api", async () => {
+        it("should pass when verificationScore is 2 and cri is di-ipv-cri-kbv-api", async () => {
             const client_id = "request-client-id";
             const redirect_uri = "redirect-uri";
             const state = "state";

--- a/lambdas/tests/unit/services/session-request-validator.test.ts
+++ b/lambdas/tests/unit/services/session-request-validator.test.ts
@@ -27,7 +27,7 @@ describe("session-request-validator.ts", () => {
         });
 
         it("should return an error on JWT verification failure", async () => {
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(Promise.resolve(null));
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue(null);
 
             await expect(
                 sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), "request-client-id"),
@@ -39,13 +39,11 @@ describe("session-request-validator.ts", () => {
             );
         });
 
-        it("should return anerror on mismatched client ID", async () => {
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                Promise.resolve({
-                    client_id: "payload-client-id",
-                    shared_claims: personIdentity,
-                } as JWTPayload),
-            );
+        it("should return an error on mismatched client ID", async () => {
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: "payload-client-id",
+                shared_claims: personIdentity,
+            } as JWTPayload);
 
             await expect(
                 sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), "request-client-id"),
@@ -59,12 +57,10 @@ describe("session-request-validator.ts", () => {
         });
 
         it("should return an error on failure to retrieve redirect URI", async () => {
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                Promise.resolve({
-                    client_id: "request-client-id",
-                    shared_claims: personIdentity,
-                } as JWTPayload),
-            );
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: "request-client-id",
+                shared_claims: personIdentity,
+            } as JWTPayload);
 
             await expect(
                 sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), "request-client-id"),
@@ -78,13 +74,12 @@ describe("session-request-validator.ts", () => {
         });
 
         it("should return an error on mismatched redirect URI", async () => {
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                Promise.resolve({
-                    client_id: "request-client-id",
-                    redirect_uri: "wrong-redirect-uri",
-                    shared_claims: personIdentity,
-                } as JWTPayload),
-            );
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: "request-client-id",
+                redirect_uri: "wrong-redirect-uri",
+                shared_claims: personIdentity,
+            } as JWTPayload);
+
             mockMap.set(ClientConfigKey.JWT_REDIRECT_URI, "redirect-uri");
             sessionRequestValidator = sessionRequestValidatorFactory.create(mockMap);
 
@@ -101,14 +96,13 @@ describe("session-request-validator.ts", () => {
 
         it("should successfully validate the jwt", async () => {
             const state = "state";
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                Promise.resolve({
-                    client_id: "request-client-id",
-                    redirect_uri: "redirect-uri",
-                    state: state,
-                    shared_claims: personIdentity,
-                } as JWTPayload),
-            );
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: "request-client-id",
+                redirect_uri: "redirect-uri",
+                state: state,
+                shared_claims: personIdentity,
+            } as JWTPayload);
+
             mockMap.set(ClientConfigKey.JWT_REDIRECT_URI, "redirect-uri");
             sessionRequestValidator = sessionRequestValidatorFactory.create(mockMap);
 
@@ -122,7 +116,7 @@ describe("session-request-validator.ts", () => {
         });
     });
 
-    describe("sessionRequestValidator", () => {
+    describe("sessionRequestValidator for di-ipv-cri-check-hmrc-api", () => {
         let sessionRequestValidator: SessionRequestValidator;
         let sessionRequestValidationConfig: SessionRequestValidationConfig;
         const jwtVerifier = jest.mocked(JwtVerifier);
@@ -149,14 +143,14 @@ describe("session-request-validator.ts", () => {
                 shared_claims: personIdentity,
             } as JWTPayload;
 
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(Promise.resolve(jwtPayload));
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue(jwtPayload);
 
             const payload = (await sessionRequestValidator.validateJwt(
                 Buffer.from("test-jwt"),
                 client_id,
             )) as JWTPayload;
 
-            await expect(payload).toEqual(jwtPayload);
+            expect(payload).toEqual(jwtPayload);
         });
 
         it("should pass when strength score is 2 and cri is di-ipv-check-hmrc-api", async () => {
@@ -167,20 +161,22 @@ describe("session-request-validator.ts", () => {
             const previousCriIdentifier = process.env.CRI_IDENTIFIER;
             process.env.CRI_IDENTIFIER = "di-ipv-cri-check-hmrc-api";
 
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                await Promise.resolve({
-                    client_id: client_id,
-                    redirect_uri: redirect_uri,
-                    state: state,
-                    evidence_requested: {
-                        scoringPolicy: "gpg45",
-                        strengthScore: 2,
-                    },
-                    shared_claims: personIdentity,
-                } as JWTPayload),
-            );
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: client_id,
+                redirect_uri: redirect_uri,
+                state: state,
+                evidence_requested: {
+                    scoringPolicy: "gpg45",
+                    strengthScore: 2,
+                },
+                shared_claims: personIdentity,
+            } as JWTPayload);
 
-            await expect(async () => sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).resolves;
+            await expect(sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).resolves.toEqual(
+                expect.objectContaining({
+                    evidence_requested: { scoringPolicy: "gpg45", strengthScore: 2 },
+                }),
+            );
 
             process.env.CRI_IDENTIFIER = previousCriIdentifier;
         });
@@ -193,18 +189,16 @@ describe("session-request-validator.ts", () => {
             const previousCriIdentifier = process.env.CRI_IDENTIFIER;
             process.env.CRI_IDENTIFIER = "di-ipv-cri-check-hmrc-api";
 
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                await Promise.resolve({
-                    client_id: client_id,
-                    redirect_uri: redirect_uri,
-                    state: state,
-                    evidence_requested: {
-                        scoringPolicy: "gpg45",
-                        strengthScore: 1,
-                    },
-                    shared_claims: personIdentity,
-                } as JWTPayload),
-            );
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: client_id,
+                redirect_uri: redirect_uri,
+                state: state,
+                evidence_requested: {
+                    scoringPolicy: "gpg45",
+                    strengthScore: 1,
+                },
+                shared_claims: personIdentity,
+            } as JWTPayload);
 
             await expect(async () =>
                 sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id),
@@ -230,9 +224,7 @@ describe("session-request-validator.ts", () => {
                 } as JWTPayload),
             );
 
-            await expect(async () =>
-                sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id),
-            ).rejects.toThrow(
+            await expect(sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).rejects.toThrow(
                 expect.objectContaining({
                     message: "Session Validation Exception",
                     details: "Invalid request: scoringPolicy in evidence_requested does not equal gpg45",
@@ -245,19 +237,21 @@ describe("session-request-validator.ts", () => {
             const redirect_uri = "redirect-uri";
             const state = "state";
 
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                await Promise.resolve({
-                    client_id: client_id,
-                    redirect_uri: redirect_uri,
-                    state: state,
-                    evidence_requested: {
-                        scoringPolicy: "gpg45",
-                    },
-                    shared_claims: personIdentity,
-                } as JWTPayload),
-            );
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: client_id,
+                redirect_uri: redirect_uri,
+                state: state,
+                evidence_requested: {
+                    scoringPolicy: "gpg45",
+                },
+                shared_claims: personIdentity,
+            } as JWTPayload);
 
-            await expect(async () => sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).resolves;
+            await expect(sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).resolves.toEqual(
+                expect.objectContaining({
+                    evidence_requested: { scoringPolicy: "gpg45" },
+                }),
+            );
         });
 
         it("should pass when the there is no evidence_requested", async () => {
@@ -265,32 +259,31 @@ describe("session-request-validator.ts", () => {
             const redirect_uri = "redirect-uri";
             const state = "state";
 
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                await Promise.resolve({
-                    client_id: client_id,
-                    redirect_uri: redirect_uri,
-                    state: state,
-                    shared_claims: personIdentity,
-                } as JWTPayload),
-            );
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: client_id,
+                redirect_uri: redirect_uri,
+                state: state,
+                shared_claims: personIdentity,
+            } as JWTPayload);
 
-            await expect(async () => sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).resolves;
+            await expect(sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).resolves.toEqual({
+                client_id: "request-client-id",
+                redirect_uri: "redirect-uri",
+                shared_claims: {},
+                state: "state",
+            });
         });
         it("should fail to validate the jwt if state is missing", async () => {
             const client_id = "request-client-id";
             const redirect_uri = "redirect-uri";
 
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                Promise.resolve({
-                    client_id: client_id,
-                    redirect_uri: redirect_uri,
-                    shared_claims: personIdentity,
-                } as JWTPayload),
-            );
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: client_id,
+                redirect_uri: redirect_uri,
+                shared_claims: personIdentity,
+            } as JWTPayload);
 
-            await expect(async () =>
-                sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id),
-            ).rejects.toThrow(
+            await expect(sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).rejects.toThrow(
                 expect.objectContaining({
                     message: "Session Validation Exception",
                     details: "Invalid state parameter",
@@ -316,7 +309,7 @@ describe("session-request-validator.ts", () => {
             );
         });
 
-        it("should pass when strengthScore is 1 and cri is di-ipv-cri-kbv-api", async () => {
+        it("should pass when verificationScore is 1 and cri is di-ipv-cri-kbv-api", async () => {
             const client_id = "request-client-id";
             const redirect_uri = "redirect-uri";
             const state = "state";
@@ -324,22 +317,22 @@ describe("session-request-validator.ts", () => {
             const previousCriIdentifier = process.env.CRI_IDENTIFIER;
             process.env.CRI_IDENTIFIER = "di-ipv-cri-kbv-api";
 
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                await Promise.resolve({
-                    client_id: client_id,
-                    redirect_uri: redirect_uri,
-                    state: state,
-                    evidence_requested: {
-                        scoringPolicy: "gpg45",
-                        verificationScore: 1,
-                    },
-                    shared_claims: personIdentity,
-                } as JWTPayload),
-            );
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: client_id,
+                redirect_uri: redirect_uri,
+                state: state,
+                evidence_requested: {
+                    scoringPolicy: "gpg45",
+                    verificationScore: 1,
+                },
+                shared_claims: personIdentity,
+            } as JWTPayload);
 
-            await expect(
-                sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id),
-            ).resolves.not.toThrow();
+            await expect(sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).resolves.toEqual(
+                expect.objectContaining({
+                    evidence_requested: { scoringPolicy: "gpg45", verificationScore: 1 },
+                }),
+            );
 
             process.env.CRI_IDENTIFIER = previousCriIdentifier;
         });
@@ -352,27 +345,27 @@ describe("session-request-validator.ts", () => {
             const previousCriIdentifier = process.env.CRI_IDENTIFIER;
             process.env.CRI_IDENTIFIER = "di-ipv-cri-kbv-api";
 
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                await Promise.resolve({
-                    client_id: client_id,
-                    redirect_uri: redirect_uri,
-                    state: state,
-                    evidence_requested: {
-                        scoringPolicy: "gpg45",
-                        verificationScore: 2,
-                    },
-                    shared_claims: personIdentity,
-                } as JWTPayload),
-            );
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: client_id,
+                redirect_uri: redirect_uri,
+                state: state,
+                evidence_requested: {
+                    scoringPolicy: "gpg45",
+                    verificationScore: 2,
+                },
+                shared_claims: personIdentity,
+            } as JWTPayload);
 
-            await expect(
-                sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id),
-            ).resolves.not.toThrow();
+            await expect(sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).resolves.toEqual(
+                expect.objectContaining({
+                    evidence_requested: { scoringPolicy: "gpg45", verificationScore: 2 },
+                }),
+            );
 
             process.env.CRI_IDENTIFIER = previousCriIdentifier;
         });
 
-        it("should pass when verifcationScore is not included in evidence_requested and cri is di-ipv-cri-kbv-api", async () => {
+        it("should pass when verificationScore is 2 and cri is di-ipv-cri-kbv-api and configured with strengthScore & verificationScore", async () => {
             const client_id = "request-client-id";
             const redirect_uri = "redirect-uri";
             const state = "state";
@@ -380,26 +373,33 @@ describe("session-request-validator.ts", () => {
             const previousCriIdentifier = process.env.CRI_IDENTIFIER;
             process.env.CRI_IDENTIFIER = "di-ipv-cri-kbv-api";
 
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                await Promise.resolve({
-                    client_id: client_id,
-                    redirect_uri: redirect_uri,
-                    state: state,
-                    evidence_requested: {
-                        scoringPolicy: "gpg45",
-                    },
-                    shared_claims: personIdentity,
-                } as JWTPayload),
+            sessionRequestValidator = new SessionRequestValidator(
+                sessionRequestValidationConfig,
+                jwtVerifier.prototype,
+                { strengthScore: 2, verificationScore: [1, 2] } as CRIEvidenceProperties,
             );
 
-            await expect(
-                sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id),
-            ).resolves.not.toThrow();
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: client_id,
+                redirect_uri: redirect_uri,
+                state: state,
+                evidence_requested: {
+                    scoringPolicy: "gpg45",
+                    verificationScore: 2,
+                },
+                shared_claims: personIdentity,
+            } as JWTPayload);
+
+            await expect(sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).resolves.toEqual(
+                expect.objectContaining({
+                    evidence_requested: { scoringPolicy: "gpg45", verificationScore: 2 },
+                }),
+            );
 
             process.env.CRI_IDENTIFIER = previousCriIdentifier;
         });
 
-        it("should fail when verifcationScore is not 1,2 or empty and cri is di-ipv-cri-kbv-api", async () => {
+        it("should pass when verificationScore is not included in evidence_requested and cri is di-ipv-cri-kbv-api", async () => {
             const client_id = "request-client-id";
             const redirect_uri = "redirect-uri";
             const state = "state";
@@ -407,18 +407,43 @@ describe("session-request-validator.ts", () => {
             const previousCriIdentifier = process.env.CRI_IDENTIFIER;
             process.env.CRI_IDENTIFIER = "di-ipv-cri-kbv-api";
 
-            jest.spyOn(jwtVerifier.prototype, "verify").mockReturnValue(
-                await Promise.resolve({
-                    client_id: client_id,
-                    redirect_uri: redirect_uri,
-                    state: state,
-                    evidence_requested: {
-                        scoringPolicy: "gpg45",
-                        verificationScore: 3,
-                    },
-                    shared_claims: personIdentity,
-                } as JWTPayload),
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: client_id,
+                redirect_uri: redirect_uri,
+                state: state,
+                evidence_requested: {
+                    scoringPolicy: "gpg45",
+                },
+                shared_claims: personIdentity,
+            } as JWTPayload);
+
+            await expect(sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id)).resolves.toEqual(
+                expect.objectContaining({
+                    evidence_requested: { scoringPolicy: "gpg45" },
+                }),
             );
+
+            process.env.CRI_IDENTIFIER = previousCriIdentifier;
+        });
+
+        it("should fail when verificationScore is not 1,2 or empty and cri is di-ipv-cri-kbv-api", async () => {
+            const client_id = "request-client-id";
+            const redirect_uri = "redirect-uri";
+            const state = "state";
+
+            const previousCriIdentifier = process.env.CRI_IDENTIFIER;
+            process.env.CRI_IDENTIFIER = "di-ipv-cri-kbv-api";
+
+            jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
+                client_id: client_id,
+                redirect_uri: redirect_uri,
+                state: state,
+                evidence_requested: {
+                    scoringPolicy: "gpg45",
+                    verificationScore: 3,
+                },
+                shared_claims: personIdentity,
+            } as JWTPayload);
 
             await expect(async () =>
                 sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id),

--- a/lambdas/tests/unit/services/session-request-validator.test.ts
+++ b/lambdas/tests/unit/services/session-request-validator.test.ts
@@ -292,7 +292,7 @@ describe("session-request-validator.ts", () => {
         });
     });
 
-    describe("sessionRequestValidator for di-ipv-cri-kbv-api", () => {
+    describe("isValidVerificationScore tests", () => {
         let sessionRequestValidator: SessionRequestValidator;
         let sessionRequestValidationConfig: SessionRequestValidationConfig;
         const jwtVerifier = jest.mocked(JwtVerifier);
@@ -309,13 +309,10 @@ describe("session-request-validator.ts", () => {
             );
         });
 
-        it("should pass when verificationScore is 1 and cri is di-ipv-cri-kbv-api", async () => {
+        it("should pass when evidence_requested verificationScore is 1 and CRIEvidenceProperties verficiation score contains 1", async () => {
             const client_id = "request-client-id";
             const redirect_uri = "redirect-uri";
             const state = "state";
-
-            const previousCriIdentifier = process.env.CRI_IDENTIFIER;
-            process.env.CRI_IDENTIFIER = "di-ipv-cri-kbv-api";
 
             jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
                 client_id: client_id,
@@ -333,17 +330,12 @@ describe("session-request-validator.ts", () => {
                     evidence_requested: { scoringPolicy: "gpg45", verificationScore: 1 },
                 }),
             );
-
-            process.env.CRI_IDENTIFIER = previousCriIdentifier;
         });
 
-        it("should pass when verificationScore is 2 and cri is di-ipv-cri-kbv-api", async () => {
+        it("should pass when evidence_requested verificationScore is 2 and CRIEvidenceProperties verficiation score contains 2", async () => {
             const client_id = "request-client-id";
             const redirect_uri = "redirect-uri";
             const state = "state";
-
-            const previousCriIdentifier = process.env.CRI_IDENTIFIER;
-            process.env.CRI_IDENTIFIER = "di-ipv-cri-kbv-api";
 
             jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
                 client_id: client_id,
@@ -361,17 +353,12 @@ describe("session-request-validator.ts", () => {
                     evidence_requested: { scoringPolicy: "gpg45", verificationScore: 2 },
                 }),
             );
-
-            process.env.CRI_IDENTIFIER = previousCriIdentifier;
         });
 
-        it("should pass when verificationScore is 2 and cri is di-ipv-cri-kbv-api and configured with strengthScore & verificationScore", async () => {
+        it("should pass when evidence_requested verificationScore and strength score match CRIEvidenceProperties", async () => {
             const client_id = "request-client-id";
             const redirect_uri = "redirect-uri";
             const state = "state";
-
-            const previousCriIdentifier = process.env.CRI_IDENTIFIER;
-            process.env.CRI_IDENTIFIER = "di-ipv-cri-kbv-api";
 
             sessionRequestValidator = new SessionRequestValidator(
                 sessionRequestValidationConfig,
@@ -395,17 +382,12 @@ describe("session-request-validator.ts", () => {
                     evidence_requested: { scoringPolicy: "gpg45", verificationScore: 2 },
                 }),
             );
-
-            process.env.CRI_IDENTIFIER = previousCriIdentifier;
         });
 
-        it("should pass when verificationScore is not included in evidence_requested and cri is di-ipv-cri-kbv-api", async () => {
+        it("should pass when evidence_requested verificationScore is not included", async () => {
             const client_id = "request-client-id";
             const redirect_uri = "redirect-uri";
             const state = "state";
-
-            const previousCriIdentifier = process.env.CRI_IDENTIFIER;
-            process.env.CRI_IDENTIFIER = "di-ipv-cri-kbv-api";
 
             jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
                 client_id: client_id,
@@ -422,17 +404,12 @@ describe("session-request-validator.ts", () => {
                     evidence_requested: { scoringPolicy: "gpg45" },
                 }),
             );
-
-            process.env.CRI_IDENTIFIER = previousCriIdentifier;
         });
 
-        it("should fail when verificationScore is not 1,2 or empty and cri is di-ipv-cri-kbv-api", async () => {
+        it("should fail when evidence_requested verificationScore is 3 and CRIEvidenceProperties verficiation score only contains 1 and 2", async () => {
             const client_id = "request-client-id";
             const redirect_uri = "redirect-uri";
             const state = "state";
-
-            const previousCriIdentifier = process.env.CRI_IDENTIFIER;
-            process.env.CRI_IDENTIFIER = "di-ipv-cri-kbv-api";
 
             jest.spyOn(jwtVerifier.prototype, "verify").mockResolvedValue({
                 client_id: client_id,
@@ -448,8 +425,6 @@ describe("session-request-validator.ts", () => {
             await expect(async () =>
                 sessionRequestValidator.validateJwt(Buffer.from("test-jwt"), client_id),
             ).rejects.toThrow(new Error("Session Validation Exception"));
-
-            process.env.CRI_IDENTIFIER = previousCriIdentifier;
         });
     });
 

--- a/lambdas/tests/unit/services/session-request-validator.test.ts
+++ b/lambdas/tests/unit/services/session-request-validator.test.ts
@@ -135,6 +135,7 @@ describe("session-request-validator.ts", () => {
             sessionRequestValidator = new SessionRequestValidator(
                 sessionRequestValidationConfig,
                 jwtVerifier.prototype,
+                { strengthScore: 2 } as CRIEvidenceProperties,
             );
         });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

- Added the use of an optional CRIEvidenceProperties parameter to validate evidence requested values. 
- Removed the strengthScore parameter for all CRIs (now included in the CRIEvidenceProperties)
- Added verificationScore validation to the session-request-validator
- Modified config service parameter retrieval to only log if the CRIEvidenceProperties parameter is not found
- Added tests for the verificationScore validation. 
- Refactor some of the tests


### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
I want the system to support a Low Confidence journey for kbv by validating a verification score of 1 &  2 in the EvidenceRequest from ipv-core.


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2641](https://govukverify.atlassian.net/browse/OJ-2641)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2641]: https://govukverify.atlassian.net/browse/OJ-2641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ