### PR TITLE
Adds gradle scanning to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       - dependabot
     commit-message:
       prefix: BAU
+  - package-ecosystem: "gradle" 
+    directory: "/" 
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Proposed changes

### What changed

Adds gradle scanning to dependabot as per the [recommended implementation from team manual](https://team-manual.account.gov.uk/development-standards-processes/coding-practices-and-processes/dependabot/#meeting-development-standards)

Note this is a copy of PR https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/286
