### PR TITLE
LIME-1071 Update to CRI Lib 3.0.1 and align with service changes.

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -23,6 +23,8 @@ jobs:
     name: Build SAM app
     runs-on: ubuntu-latest
     permissions: {}
+    outputs:
+      sha_short: ${{ steps.vars.outputs.sha_short }}    
     steps:
       - name: Pull repository
         uses: actions/checkout@v4
@@ -39,12 +41,17 @@ jobs:
           distribution: zulu
           cache: gradle
 
+      - name: Get short-sha
+        id: vars
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Build SAM application
         uses: govuk-one-login/github-actions/sam/build-application@cf644c0d66c41259bfe2509852d1211e3f01f44d
         id: build
         with:
           template: infrastructure/lambda/template.yaml
-          cache-key: common-lambdas
+          cache-name: common-lambdas-${{ steps.vars.outputs.sha_short }}
           pull-repository: false
 
   deploy:
@@ -70,7 +77,7 @@ jobs:
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
           stack-name-prefix: preview-common-lambdas
           stack-name-length-limit: 37
-          cache-key: common-lambdas
+          cache-name: common-lambdas-${{ needs.build.outputs.sha_short}}
           s3-prefix: preview
           pull-repository: true
           delete-failed-stack: true

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ build
 *.env
 integration-tests/target
 
+# vscode
+.vscode
 
 accesstoken/bin/
 authorization/bin/

--- a/accesstoken/build.gradle
+++ b/accesstoken/build.gradle
@@ -7,6 +7,8 @@ plugins {
 dependencies {
 	implementation configurations.cri_common_lib,
 			configurations.aws,
+			configurations.aws_crt_client,
+			configurations.dynamodb,
 			configurations.lambda,
 			configurations.nimbus,
 			configurations.jackson

--- a/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/AccessTokenHandlerTest.java
+++ b/accesstoken/src/test/java/uk/gov/di/ipv/cri/common/api/handler/pact/AccessTokenHandlerTest.java
@@ -31,7 +31,6 @@ import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.JWTVerifier;
 import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
-import uk.gov.di.ipv.cri.common.library.util.ListUtil;
 
 import java.io.IOException;
 import java.net.URI;
@@ -93,10 +92,7 @@ class AccessTokenHandlerTest {
                         new AccessTokenHandler(
                                 new AccessTokenService(configurationService, new JWTVerifier()),
                                 new SessionService(
-                                        dataStore,
-                                        configurationService,
-                                        Clock.systemUTC(),
-                                        new ListUtil()),
+                                        dataStore, configurationService, Clock.systemUTC()),
                                 new EventProbe()),
                         "/token",
                         "/");
@@ -163,8 +159,7 @@ class AccessTokenHandlerTest {
         sessionRequest.setClientId("ipv-core");
 
         SessionService sessionService =
-                new SessionService(
-                        dataStore, configurationService, Clock.systemUTC(), new ListUtil());
+                new SessionService(dataStore, configurationService, Clock.systemUTC());
         ArgumentCaptor<SessionItem> sessionItemArgumentCaptor =
                 ArgumentCaptor.forClass(SessionItem.class);
 

--- a/authorization/build.gradle
+++ b/authorization/build.gradle
@@ -7,6 +7,8 @@ plugins {
 dependencies {
 	implementation configurations.cri_common_lib,
 			configurations.aws,
+			configurations.aws_crt_client,
+			configurations.dynamodb,
 			configurations.lambda,
 			configurations.nimbus,
 			configurations.jackson

--- a/authorization/src/main/java/uk/gov/di/ipv/cri/common/api/service/AuthorizationValidatorService.java
+++ b/authorization/src/main/java/uk/gov/di/ipv/cri/common/api/service/AuthorizationValidatorService.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.cri.common.api.service;
 
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
-import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.exception.SessionValidationException;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
@@ -12,11 +11,6 @@ import java.util.Map;
 public class AuthorizationValidatorService {
 
     private final ConfigurationService configurationService;
-
-    @ExcludeFromGeneratedCoverageReport
-    public AuthorizationValidatorService() {
-        this.configurationService = new ConfigurationService();
-    }
 
     public AuthorizationValidatorService(ConfigurationService configurationService) {
         this.configurationService = configurationService;

--- a/build.gradle
+++ b/build.gradle
@@ -11,17 +11,17 @@ java {
 
 ext {
 	dependencyVersions = [
-
-		aws_lambda_events_version: "3.11.0",
-		jackson_version          : "2.13.1",
-		nimbusds_oauth_version   : "11.2",
+		aws_sdk_version          : "2.26.16",
+		aws_lambda_events_version: "3.11.6",
+		aws_powertools_version   : "1.18.0",
+		jackson_version          : "2.15.2",
+		nimbusds_oauth_version   : "11.4",
 		nimbusds_jwt_version     : "9.36",
 		protobuf_version         : "3.19.4",
 		junit                    : "5.10.1",
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
-		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.6.2"
+		cri_common_lib           : "3.0.1"
 	]
 }
 
@@ -71,6 +71,7 @@ subprojects {
 
 	configurations {
 		aws
+		aws_crt_client
 		dynamodb
 		cache
 		jackson
@@ -91,15 +92,15 @@ subprojects {
 		pact_tests
 	}
 
-	// The dynamodb enhanced package loads the apache-client as well as the spi-client, so
-	// we need to add the apache-client to the dependencies exclusion to not get a mismatch
 	configurations.all {
+		// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 		exclude group:"software.amazon.awssdk", module: "apache-client"
+		exclude group:"software.amazon.awssdk", module: "netty-nio-client"
 	}
 
 	dependencies {
-
-		aws platform('software.amazon.awssdk:bom:2.17.191')
+		aws platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}")
+		aws_crt_client "software.amazon.awssdk:aws-crt-client:${dependencyVersions.aws_sdk_version}"
 
 		cri_common_lib "uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib}"
 
@@ -108,7 +109,6 @@ subprojects {
 
 		lambda "software.amazon.awssdk:lambda",
 				"com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}"
-		//"org.apache.httpcomponents:httpclient:4.5.13"
 
 		sqs "software.amazon.awssdk:sqs"
 
@@ -116,20 +116,16 @@ subprojects {
 
 		lambda_tests "software.amazon.awssdk:aws-lambda-java-tests:1.1.1"
 
-		jackson "com.fasterxml.jackson.core:jackson-core:${dependencyVersions.jackson_version}",
-				"com.fasterxml.jackson.core:jackson-databind:${dependencyVersions.jackson_version}",
-				"com.fasterxml.jackson.core:jackson-annotations:${dependencyVersions.jackson_version}",
+		jackson "com.fasterxml.jackson.core:jackson-core",
+				"com.fasterxml.jackson.core:jackson-databind",
+				"com.fasterxml.jackson.core:jackson-annotations",
 				"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-				"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}",
-				"javax.annotation:javax.annotation-api:1.3.2",
-				"javax.validation:validation-api:2.0.1.Final",
-				"javax.el:javax.el-api:3.0.0",
-				"org.glassfish:javax.el:3.0.0"
+				"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}"
 
-		powertools "software.amazon.lambda:powertools-logging:${dependencyVersions.powertools_version}",
-				"software.amazon.lambda:powertools-metrics:${dependencyVersions.powertools_version}",
-				"software.amazon.lambda:powertools-tracing:${dependencyVersions.powertools_version}",
-				"software.amazon.lambda:powertools-parameters:${dependencyVersions.powertools_version}"
+		powertools "software.amazon.lambda:powertools-logging:${dependencyVersions.aws_powertools_version}",
+				"software.amazon.lambda:powertools-metrics:${dependencyVersions.aws_powertools_version}",
+				"software.amazon.lambda:powertools-tracing:${dependencyVersions.aws_powertools_version}",
+				"software.amazon.lambda:powertools-parameters:${dependencyVersions.aws_powertools_version}"
 
 		tests "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit}",
 				"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit}",

--- a/session/build.gradle
+++ b/session/build.gradle
@@ -7,6 +7,8 @@ plugins {
 dependencies {
 	implementation configurations.cri_common_lib,
 			configurations.aws,
+			configurations.aws_crt_client,
+			configurations.dynamodb,
 			configurations.lambda,
 			configurations.nimbus,
 			configurations.kms,

--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/KMSRSADecrypter.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/KMSRSADecrypter.java
@@ -30,10 +30,6 @@ class KMSRSADecrypter implements JWEDecrypter {
     private final KmsClient kmsClient;
     private final String keyId;
 
-    KMSRSADecrypter(String keyId) {
-        this(keyId, KmsClient.builder().build());
-    }
-
     KMSRSADecrypter(String keyId, KmsClient kmsClient) {
         this.keyId = keyId;
         this.kmsClient = kmsClient;


### PR DESCRIPTION
## Proposed changes

### What changed

Update to CRI Lib 3.0.1 and switch to using new constructors for services and reusing clients via ClientProviderFactory.

AWS SDK 2.20.162 -> 2.26.16 (version now set via dependencies variable)
New Aws Crt Http Client aligned with AWS SDK 2.26.16 AWS Lambda Events 3.11.0 -> 3.11.6
AWS Lambda Powertools 1.12.3 -> 1.18.0
Nimbusds Oauth 11.2 -> 11.4
Jackson 2.13.1 -> 2.15.2

Removes unused dependencies in the Jackson configuration.
Remove versions specified for the main Jackson dependencies and defer to the ones pull in from software.amazon.awss
dk:bom.
 There is a breakage in a later jackson version, which crashes in the sdk classes which expect the older versions.
Note : jackson-datatype-jsr310 and jackson-datatype-jdk8 are not in the aws sdk and are custom dependencies these version have been set at the aws pom versions

Added netty-http client to the exclusions.

Corrected deploy-branch being unaware of changes, as it was restoring and deploying the first cached build on the branch

### Why did it change

To bring in the optimisations to service creation and parameter reads provided by CRI-LIB 3.0.0. [CRI LIB 3.0.0 PR](https://github.com/govuk-one-login/ipv-cri-lib/pull/526)

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1071](https://govukverify.atlassian.net/browse/LIME-1071)

[LIME-1071]: https://govukverify.atlassian.net/browse/LIME-1071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ