### PR TITLE
OJ-2621: Added evidence_requested object to the START audit event

### DIFF
--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -66,7 +66,7 @@ export class SessionLambda implements LambdaInterface {
                 sessionRequestSummary,
                 clientIpAddress,
                 encodedDeviceInformation,
-                jwtPayload["evidence_requested"] as string,
+                jwtPayload["evidence_requested"] as EvidenceRequest,
             );
             metrics.addDimension("issuer", sessionRequestSummary.clientId);
             metrics.addMetric(SESSION_CREATED_METRIC, MetricUnits.Count, 1);
@@ -103,7 +103,7 @@ export class SessionLambda implements LambdaInterface {
         sessionRequest: SessionRequestSummary,
         clientIpAddress?: string,
         encodedDeviceInformation?: string,
-        evidenceRequested?: string,
+        evidenceRequested?: EvidenceRequest,
     ) {
         await this.auditService.sendAuditEvent(AuditEventType.START, {
             clientIpAddress: clientIpAddress,
@@ -125,6 +125,11 @@ export class SessionLambda implements LambdaInterface {
                     evidence: {
                         context: "identity_check",
                     },
+                    ...(evidenceRequested.verificationScore && {
+                        evidence_requested: {
+                            verificationScore: evidenceRequested.verificationScore,
+                        },
+                    }),
                 },
             }),
         });


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Added evidence_requested object to the START audit event, this includes the verificationScore so we can see the requested journey for kbv

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To ensure the TxMA events for the Experian KBV API include the correct verification score and evidence requested,

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2621](https://govukverify.atlassian.net/browse/OJ-2621)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2621]: https://govukverify.atlassian.net/browse/OJ-2621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ