### PR TITLE
OJ-2769: Update client callback url param identifier to nino

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -399,7 +399,7 @@ Mappings:
     di-ipv-cri-check-hmrc-api:
       staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=nino"
       integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=nino"
-      production: "https://identity.account.gov.uk/credential-issuer/callback?id=checkHmrc"
+      production: "https://identity.account.gov.uk/credential-issuer/callback?id=nino"
     di-ipv-cri-kbv-hmrc-api:
       staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=hmrcKbv"
       integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=hmrcKbv"


### PR DESCRIPTION
As part of ensuring we are properly configured for `pre-prod`

see: https://govukverify.atlassian.net/browse/OJ-2769

ipv-core uses nino to identify Check-hmrc

### Why did it change

Wrong id value as can be confirmed 
corresponding configuration can be found [here](https://github.com/govuk-one-login/ipv-core-common-infra/blob/main/utils/config-mgmt/app/configs/core.production.params.yaml#L320):

