### PR TITLE
Set IsCSLSDisabled for the common account

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -66,7 +66,9 @@ Conditions:
           - "none"
   IsCSLSDisabled: !And
     - !Not
-      - !Equals [!Ref CriIdentifier, "di-ipv-cri-kbv-hmrc-api"]
+      - !Or
+        - !Equals [!Ref CriIdentifier, "di-ipv-cri-kbv-hmrc-api"]
+        - !Equals [!Ref CriIdentifier, "di-ipv-cri-toy-api"]
     - !Not
       - !Equals [!Ref Environment, "dev"]
   UseNewCSLSDestinationArn: !Equals


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Set IsCSLSDisabled to true for the common account

### Why did it change

The stack is failing to deploy to the `di-ipv-cri-common-build` account because of the error

```
Resource handler returned message: "User with accountId: 667736788427 is not authorized to perform: 
logs:PutSubscriptionFilter on resource: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython 
(Service: CloudWatchLogs, Status Code: 400, Request ID: 1f88ba51-69c6-420b-8d42-ed88b504c155)" 
(RequestToken: 1c829f56-384b-c463-74bb-2b8758f16180, HandlerErrorCode: AccessDenied)
```

I can't see that in the last year we've had logs for the `di-ipv-cri-toy-api` CRI in Splunk and as this only exists for dev/build I don't think we need the logs going to Splunk. 

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed
