### PR TITLE
OJ-2736: `/events` endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12638,6 +12638,7 @@
       }
     },
     "test-resources/test-harness/lambdas": {
+      "name": "test-harness",
       "dependencies": {
         "@aws-lambda-powertools/commons": "2.7.0",
         "@aws-lambda-powertools/logger": "2.7.0",

--- a/test-resources/test-harness/infrastructure/public-api.yaml
+++ b/test-resources/test-harness/infrastructure/public-api.yaml
@@ -1,0 +1,98 @@
+openapi: 3.0.1
+info:
+  title: "Test harness"
+  version: "1.0"
+
+paths:
+  /events:
+    get:
+      security:
+        - sigv4Reference: [ ]
+      description: Retrieve events from DynamoDB events table. Used for testing purposes only.
+      parameters:
+        - name: partitionKey
+          in: query
+          required: true
+          description: Partition key to use in events table query.
+          schema:
+            type: string
+        - name: sortKey
+          in: query
+          required: true
+          description: Sort key to use in events table query.
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        400:
+          description: Bad request, missing partitionKey or sortKey
+        500:
+          description: Internal server error
+      x-amazon-apigateway-request-validator: Validate both
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        passThroughBehavior: when_no_templates
+        type: aws
+        credentials:
+          Fn::Sub: ${AuditEventsTableRole.Arn}
+        uri:
+          Fn::Sub:
+            arn:aws:apigateway:${AWS::Region}:dynamodb:action/Query
+        requestTemplates:
+          application/json:
+            Fn::Sub:
+              - >
+                #set($partitionKey = $input.params('partitionKey'))
+                #set($sortKey = $input.params('sortKey'))
+                {
+                  "TableName": "${table}",
+                  "KeyConditionExpression": "partitionKey = :partitionKey AND begins_with(sortKey, :sortKey)",
+                  "ExpressionAttributeValues": {
+                    ":partitionKey": {
+                      "S": "$partitionKey"
+                    },
+                    ":sortKey": {
+                      "S": "$sortKey"
+                    }
+                  },
+                  "ProjectionExpression": "partitionKey, sortKey, event"
+                }
+              - table:
+                  Ref: AuditEventsTable
+        responses:
+          default:
+            statusCode: 200
+            responseTemplates:
+              application/json: |
+                $input.json('$.Items')
+
+x-amazon-apigateway-request-validators:
+  Validate both:
+    validateRequestBody: true
+    validateRequestParameters: true
+
+x-amazon-apigateway-policy:
+  Version: "2012-10-17"
+  Statement:
+    - Effect: "Deny"
+      Principal:
+        AWS:  "*"
+      Action: "execute-api:Invoke"
+      Resource: "execute-api:/*"
+      Condition:
+        StringNotEquals:
+          "aws:PrincipalAccount":
+            - "${AWS::AccountId}"
+
+components:
+  securitySchemes:
+    sigv4Reference:
+      type: apiKey
+      name: Authorization
+      in: header
+      x-amazon-apigateway-authtype: awsSigv4

--- a/test-resources/test-harness/infrastructure/samconfig.toml
+++ b/test-resources/test-harness/infrastructure/samconfig.toml
@@ -1,11 +1,20 @@
 version = 0.1
-[dev]
-[dev.deploy]
-[dev.deploy.parameters]
+[default.deploy.parameters]
 stack_name = "test-harness"
+resolve_s3 = true
+s3_prefix = "test-harness"
 region = "eu-west-2"
-confirm_changeset = false
-capabilities = "CAPABILITY_IAM CAPABILITY_NAMED_IAM"
-parameter_overrides = "CodeSigningConfigArn=\"none\" Environment=\"dev\" PermissionsBoundary=\"none\" SecretPrefix=\"none\""
-tags = ["cri:deployment-source=manual", "cri:stack-type=dev", "cri:component=ipv-cri-common-test-harness"]
+capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"]
+parameter_overrides = [
+    "CodeSigningConfigArn=none",
+    "PermissionsBoundary=none",
+    "CriIdentifier=/common-cri-parameters/CriIdentifier",
+    "TxmaStackName=txma-infrastructure",
+    "Environment=dev",
+]
 image_repositories = []
+tags = [
+    "cri:deployment-source=manual",
+    "cri:stack-type=dev",
+    "cri:component=ipv-cri-common-test-harness"
+]

--- a/test-resources/test-harness/infrastructure/template.yaml
+++ b/test-resources/test-harness/infrastructure/template.yaml
@@ -25,6 +25,21 @@ Parameters:
     Default: dev
     AllowedValues: [dev, localdev, build, staging]
     ConstraintDescription: must be dev, localdev, build or staging
+  VpcStackName:
+    Type: String
+    Default: "cri-vpc"
+    Description: The name of the VPC stack deployed.
+
+Mappings:
+  TestHarnessUrl:
+      di-ipv-cri-check-hmrc-api:
+        dev: review-hc.dev.account.gov.uk
+        build: review-hc.build.account.gov.uk
+        staging: review-hc.staging.account.gov.uk
+      di-ipv-cri-address-api:
+        dev: review-a.dev.account.gov.uk
+        build: review-a.build.account.gov.uk
+        staging: review-a.staging.account.gov.uk
 
 Conditions:
   UseCodeSigningConfigArn:
@@ -37,7 +52,6 @@ Conditions:
       - Fn::Equals:
           - !Ref PermissionsBoundary
           - "none"
-
 Globals:
   Function:
     Runtime: nodejs18.x
@@ -68,6 +82,20 @@ Globals:
     AutoPublishAlias: live
 
 Resources:
+  LambdaEgressSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: >-
+        Permits outbound on port 443 from within the VPC to the internet.
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow to the wider internet on port 443
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+      VpcId:
+        Fn::ImportValue: !Sub "${VpcStackName}-VpcId"
+
   DequeueFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -186,6 +214,60 @@ Resources:
       LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-test-harness-AccessLogs
       RetentionInDays: 30
 
+  TestHarnessCustomDomain:
+    Type: AWS::ApiGatewayV2::DomainName
+    Properties:
+      DomainName: !Sub
+        - ${AWS::StackName}.${TESTHARNESSURL}
+        - TESTHARNESSURL:
+            !FindInMap [ TestHarnessUrl, !Ref CriIdentifier, !Ref Environment ]
+      DomainNameConfigurations:
+        - CertificateArn: !Ref ExternalCertificate
+          EndpointType: REGIONAL
+          SecurityPolicy: TLS_1_2
+
+  ExternalCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Sub
+        - ${AWS::StackName}.${TESTHARNESSURL}
+        - TESTHARNESSURL:
+            !FindInMap [ TestHarnessUrl, !Ref CriIdentifier, !Ref Environment ]
+      SubjectAlternativeNames:
+        - !Sub
+          - ${AWS::StackName}.${TESTHARNESSURL}
+          - TESTHARNESSURL:
+              !FindInMap [ TestHarnessUrl, !Ref CriIdentifier, !Ref Environment ]
+      DomainValidationOptions:
+        - DomainName:  !Sub
+            - ${AWS::StackName}.${TESTHARNESSURL}
+            - TESTHARNESSURL:
+                !FindInMap [ TestHarnessUrl, !Ref CriIdentifier, !Ref Environment ]
+          HostedZoneId: !ImportValue PublicHostedZoneId
+      ValidationMethod: DNS
+
+  TestHarnessApiDomainRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: !Ref TestHarnessCustomDomain
+      Type: A
+      HostedZoneId: !ImportValue PublicHostedZoneId
+      AliasTarget:
+        DNSName: !GetAtt TestHarnessCustomDomain.RegionalDomainName
+        HostedZoneId: !GetAtt TestHarnessCustomDomain.RegionalHostedZoneId
+        EvaluateTargetHealth: false
+
+  # Base Path Mapping
+  TestHarnessApiBasePathMapping:
+    Type: AWS::ApiGateway::BasePathMapping
+    Properties:
+      DomainName: !Ref TestHarnessCustomDomain
+      RestApiId: !Ref APIGateway
+
+      # workaround for sam bug - see https://github.com/aws/serverless-application-model/issues/192#issuecomment-520893111
+      # noinspection YamlUnresolvedReferences
+      Stage: !Ref APIGateway.Stage
+
   AuditEventsTableRole:
     Type: AWS::IAM::Role
     Properties:
@@ -206,3 +288,12 @@ Resources:
                 Action:
                   - dynamodb:Query
                 Resource: !GetAtt AuditEventsTable.Arn
+
+Outputs:
+  TestHarnessExecuteUrl:
+    Description: API Gateway endpoint URL for the test harness endpoints
+    Export:
+      Name: !Sub ${AWS::StackName}-TestHarnessExecuteUrl
+    Value: !Sub
+      - https://${URL}/
+      - URL: !Ref TestHarnessCustomDomain

--- a/test-resources/test-harness/infrastructure/template.yaml
+++ b/test-resources/test-harness/infrastructure/template.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: "AWS::Serverless-2016-10-31"
+Transform: [ AWS::LanguageExtensions, AWS::Serverless-2016-10-31 ]
 Description: "Digital Identity CRI Test Automation Harness"
 
 Parameters:
@@ -20,6 +20,11 @@ Parameters:
     Description: "The stack containing the TXMA infrastructure"
     Type: String
     Default: txma-infrastructure
+  Environment:
+    Type: String
+    Default: dev
+    AllowedValues: [dev, localdev, build, staging]
+    ConstraintDescription: must be dev, localdev, build or staging
 
 Conditions:
   UseCodeSigningConfigArn:
@@ -136,3 +141,68 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: expiryDate
         Enabled: true
+
+  APIGateway:
+    Type: AWS::Serverless::Api
+    Properties:
+      Description: APIGW for the test harness
+      StageName: !Ref Environment
+      TracingEnabled: true
+      MethodSettings:
+        - LoggingLevel: INFO
+          ResourcePath: "/*"
+          HttpMethod: "*"
+          DataTraceEnabled: true
+          MetricsEnabled: true
+          ThrottlingRateLimit: 10000
+          ThrottlingBurstLimit: 20000
+      AccessLogSetting:
+        DestinationArn: !GetAtt ApiAccessLogGroup.Arn
+        Format:
+          Fn::ToJsonString:
+            requestId: $context.requestId
+            ip: $context.identity.sourceIp
+            requestTime: $context.requestTime
+            httpMethod: $context.httpMethod
+            path: $context.path
+            routeKey: $context.routeKey
+            status: $context.status
+            protocol: $context.protocol
+            responseLatency: $context.responseLatency
+            responseLength: $context.responseLength
+      DefinitionBody:
+        openapi: 3.0.1
+        Fn::Transform:
+          Name: AWS::Include
+          Parameters:
+            Location: public-api.yaml
+      OpenApiVersion: 3.0.1
+      EndpointConfiguration:
+        Type: REGIONAL
+
+  ApiAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-test-harness-AccessLogs
+      RetentionInDays: 30
+
+  AuditEventsTableRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: Allow APIGW to read from the AuditEventsTable
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: apigateway.amazonaws.com
+      Policies:
+        - PolicyName: DynamoDBReadPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:Query
+                Resource: !GetAtt AuditEventsTable.Arn


### PR DESCRIPTION
## Proposed changes

### What changed
Created a new endpoint called `/events` which allows you to query the "audit events table".
There is also a new domain name associated with this endpoint in the format:  `<stackName>.<Environment>.account.gov.uk/` e.g. `https://test-resources.review-hc.dev.account.gov.uk/`

This events API takes 2 query string parameters; partitionKey and sortKey. 

### Why did it change
To support the test strategy with the test harness approach. 

Sample API output:
```
[{"sortKey":{"S":"TXMA#IPV_HMRC_RECORD_CHECK_CRI_START#1726084120#69de99e1-7a75-4abf-b355-7b9e3c3c52b9"},"event":{"S":"{\"component_id\":\"https://review-hc.dev.account.gov.uk\",\"event_name\":\"IPV_HMRC_RECORD_CHECK_CRI_START\",\"extensions\":{\"evidence\":{\"context\":\"identity_check\"}},\"restricted\":{\"device_information\":{\"encoded\":\"eyJhdWRpdF9oZWFkZXJfdmVyc2lvbiI6IjEuNC4yIiwicmVxdWVzdF90aW1lc3RhbXBfbXMiOjE3MjYwODQxMjA2NDcsImlwX2FkZHJlc3MiOiIxMy40Mi4yNy4yNTEiLCJjb3VudHJ5X2NvZGUiOiJHQiIsInVzZXJfYWdlbnQiOiJNb3ppbGxhLzUuMCAoWDExOyBMaW51eCB4ODZfNjQpIEFwcGxlV2ViS2l0LzUzNy4zNiAoS0hUTUwsIGxpa2UgR2Vja28pIEhlYWRsZXNzQ2hyb21lLzEyMS4wLjYxNjcuMTM5IFNhZmFyaS81MzcuMzYgQ2xvdWRXYXRjaFN5bnRoZXRpY3MvYXJuOmF3czpzeW50aGV0aWNzOmV1LXdlc3QtMjo1NjI2NzAyNjY0OTY6Y2FuYXJ5Omthcm9sLXN0LWhhcHB5IiwiamEzX2ZpbmdlcnByaW50IjoiOTUzYTVlM2JiMTc0ZDUxNjljNGVjNzJiYmM3MTc5YWIiLCJjb25uZWN0aW9uX3BvcnQiOjU3NjkwfQ\"}},\"timestamp\":1726084120,\"event_timestamp_ms\":1726084120820,\"user\":{\"govuk_signin_journey_id\":\"64c8253a-959c-4e3d-b882-5418d0db7f92\",\"ip_address\":\"13.42.27.251, 10.0.12.206\",\"persistent_session_id\":\"b80f685e-a655-4aba-aa51-571bdbe4be49\",\"session_id\":\"0831772a-7ac2-42a5-8aca-3aca4ffcb8f8\",\"user_id\":\"urn:fdc:gov.uk:2022:b2f0924a-6e4d-44bc-84fe-652c660c16a3\"}}"},"partitionKey":{"S":"SESSION#0831772a-7ac2-42a5-8aca-3aca4ffcb8f8"}}]
```

### Issue tracking
- [OJ-2736](https://govukverify.atlassian.net/browse/OJ-2736)


[OJ-2736]: https://govukverify.atlassian.net/browse/OJ-2736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ