### PR TITLE
OJ-2785: Fix - Update evidence object to use array

### DIFF
--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -123,9 +123,11 @@ export class SessionLambda implements LambdaInterface {
             }),
             ...(evidenceRequested && {
                 extensions: {
-                    evidence: {
-                        context: "identity_check",
-                    },
+                    evidence: [
+                        {
+                            context: "identity_check",
+                        },
+                    ],
                     ...(evidenceRequested.verificationScore && {
                         evidence_requested: {
                             verificationScore: evidenceRequested.verificationScore,

--- a/lambdas/tests/unit/handlers/session-handler.test.ts
+++ b/lambdas/tests/unit/handlers/session-handler.test.ts
@@ -493,9 +493,11 @@ describe("SessionLambda", () => {
                     clientSessionId: "test-journey-id",
                 },
                 extensions: {
-                    evidence: {
-                        context: "identity_check",
-                    },
+                    evidence: [
+                        {
+                            context: "identity_check",
+                        },
+                    ],
                     evidence_requested: {
                         verificationScore: 2,
                     },
@@ -534,9 +536,11 @@ describe("SessionLambda", () => {
                     clientSessionId: "test-journey-id",
                 },
                 extensions: {
-                    evidence: {
-                        context: "identity_check",
-                    },
+                    evidence: [
+                        {
+                            context: "identity_check",
+                        },
+                    ],
                 },
             });
         });


### PR DESCRIPTION
## Proposed changes

### What changed

The "extensions" object in the START event is updated to use `evidence` as an array
<img width="820" alt="Screenshot 2024-09-25 at 10 47 24" src="https://github.com/user-attachments/assets/003ee1d6-7d7a-4d64-bd07-56003443fd92">




### Why did it change

DAP had problems with processing extensions object since the evidence block in other audit events is normally an array.

### Issue tracking

- [OJ-2785](https://govukverify.atlassian.net/browse/OJ-2785)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2785]: https://govukverify.atlassian.net/browse/OJ-2785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ