### PR TITLE
OJ-2812: Add context claim to session if present in JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
 		junit                    : "5.10.1",
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
-		cri_common_lib           : "3.0.1"
+		cri_common_lib           : "3.1.0"
 	]
 }
 

--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestService.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestService.java
@@ -30,6 +30,7 @@ public class SessionRequestService {
     private static final String CLIENT_ID = "client_id";
     private static final String PERSISTENT_SESSION_ID = "persistent_session_id";
     private static final String CLIENT_SESSION_ID = "govuk_signin_journey_id";
+    private static final String CONTEXT = "context";
 
     private final ObjectMapper objectMapper;
     private final JWTVerifier jwtVerifier;
@@ -127,6 +128,10 @@ public class SessionRequestService {
                                         jwtClaims.getClaim(SHARED_CLAIMS_NAME)),
                                 SharedClaims.class);
                 sessionRequest.setSharedClaims(sharedClaims);
+            }
+
+            if (jwtClaims.getClaims().containsKey(CONTEXT)) {
+                sessionRequest.setContext(jwtClaims.getStringClaim(CONTEXT));
             }
 
             return sessionRequest;

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SignedJWTBuilder.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SignedJWTBuilder.java
@@ -10,6 +10,7 @@ import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ResponseType;
+import software.amazon.awssdk.utils.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,6 +50,7 @@ class SignedJWTBuilder {
     private String persistentSessionId = "persistentSessionIdTest";
     private String clientSessionId = "clientSessionIdTest";
     private Map<String, Object> sharedClaims = null;
+    private String context;
 
     SignedJWTBuilder setNow(Instant now) {
         this.now = now;
@@ -120,6 +122,11 @@ class SignedJWTBuilder {
         return this;
     }
 
+    SignedJWTBuilder setContext(String context) {
+        this.context = context;
+        return this;
+    }
+
     Certificate getCertificate() {
         return certificate;
     }
@@ -161,6 +168,10 @@ class SignedJWTBuilder {
                 if (Objects.nonNull(sharedClaims)) {
                     jwtClaimSetBuilder.claim("shared_claims", this.sharedClaims);
                 }
+            }
+
+            if (!StringUtils.isEmpty(context)) {
+                jwtClaimSetBuilder.claim("context", this.context);
             }
 
             SignedJWT signedJWT =


### PR DESCRIPTION
## Proposed changes

### What changed

To retrieve the context claim (if present) from the JAR and store in the session.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

To allow context to be passed through to the CRI. 

### Issue tracking

- [OJ-2812](https://govukverify.atlassian.net/browse/OJ-2812)


[OJ-2812]: https://govukverify.atlassian.net/browse/OJ-2812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ