### PR TITLE
OJ-2738: Don't deploy common lambdas on changes to test resources

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -21,10 +21,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        CRI_PROVIDER: ["PassportTokenProvider","DrivingLicenceTokenProvider","FraudTokenProvider","AddressCriTokenProvider"]
+        cri-provider: ["PassportTokenProvider","DrivingLicenceTokenProvider","FraudTokenProvider","AddressCriTokenProvider"]
     uses: ./.github/workflows/run-pact-tests-java.yml
     with:
-      CRI_UNDER_TEST: ${{ matrix.CRI_PROVIDER }}
+      cri-provider: ${{ matrix.cri-provider }}
     secrets:
       pact-broker-host: ${{ secrets.PACT_BROKER_HOST }}
       pact-broker-username: ${{ secrets.PACT_BROKER_USERNAME }}
@@ -35,10 +35,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        CRI_PROVIDER: ["ExperianKbvCriTokenProvider","NinoCriTokenProvider"]
+        cri-provider: ["ExperianKbvCriTokenProvider","NinoCriTokenProvider"]
     uses: ./.github/workflows/run-pact-tests-ts.yml
     with:
-      CRI_UNDER_TEST: ${{ matrix.CRI_PROVIDER }}
+      cri-provider: ${{ matrix.cri-provider }}
     secrets:
       pact-broker-host: ${{ secrets.PACT_BROKER_HOST }}
       pact-broker-username: ${{ secrets.PACT_BROKER_USERNAME }}

--- a/.github/workflows/package-common-lambdas.yml
+++ b/.github/workflows/package-common-lambdas.yml
@@ -6,7 +6,9 @@ on:
     branches: [main]
     paths-ignore: [test-resources/**]
 
-concurrency: post-merge-matrix-build-and-package
+concurrency:
+  group: package-common-lambdas
+  cancel-in-progress: false
 
 jobs:
   build_common_cri:

--- a/.github/workflows/package-common-lambdas.yml
+++ b/.github/workflows/package-common-lambdas.yml
@@ -1,9 +1,10 @@
-name: Build and package common CRI
+name: Package common lambdas
+
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - main
-  workflow_dispatch: # deploy manually
+    branches: [main]
+    paths-ignore: [test-resources/**]
 
 concurrency: post-merge-matrix-build-and-package
 

--- a/.github/workflows/package-common-lambdas.yml
+++ b/.github/workflows/package-common-lambdas.yml
@@ -60,14 +60,21 @@ jobs:
             out/
           key: "${{ github.sha }}"
 
-
   sign_and_publish_common_cri_to_dev:
+    name: Sign and publish common_cri infrastructure to Dev
     needs: build_common_cri
+    runs-on: ubuntu-latest
     continue-on-error: true
+    timeout-minutes: 10
+    env:
+      AWS_REGION: eu-west-2
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
-        target: [ ADDRESS_DEV, COMMON_DEV, DL_DEV, FRAUD_DEV, KBV_DEV, PASSPORTA_DEV, TOY_DEV, HMRC_KBV_DEV, HMRC_CHECK_DEV ]
+        target: [ADDRESS_DEV, COMMON_DEV, DL_DEV, FRAUD_DEV, KBV_DEV, PASSPORTA_DEV, TOY_DEV, HMRC_KBV_DEV, HMRC_CHECK_DEV]
         include:
           - target: ADDRESS_DEV
             ENABLED: "${{ vars.ADDRESS_DEV_ENABLED }}"
@@ -114,17 +121,7 @@ jobs:
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_CHECK_DEV_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:         HMRC_CHECK_DEV_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME:               HMRC_CHECK_DEV_SIGNING_PROFILE_NAME
-
-    name: Sign and publish common_cri infrastructure to Dev
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    env:
-      AWS_REGION: eu-west-2
-    permissions:
-      id-token: write
-      contents: read
     steps:
-
       - name: Checkout code
         if: matrix.ENABLED == 'true'
         uses: actions/checkout@v3
@@ -170,12 +167,20 @@ jobs:
           working-directory: ./out
 
   sign_and_publish_common_cri_to_build:
+    name: Sign and publish common_cri infrastructure to Build
     needs: sign_and_publish_common_cri_to_dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      AWS_REGION: eu-west-2
+    permissions:
+      id-token: write
+      contents: read
     continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
-        target: [ ADDRESS_BUILD, COMMON_BUILD, DL_BUILD, FRAUD_BUILD, KBV_BUILD, PASSPORTA_BUILD, TOY_BUILD, HMRC_KBV_BUILD, HMRC_CHECK_BUILD ]
+        target: [ADDRESS_BUILD, COMMON_BUILD, DL_BUILD, FRAUD_BUILD, KBV_BUILD, PASSPORTA_BUILD, TOY_BUILD, HMRC_KBV_BUILD, HMRC_CHECK_BUILD]
         include:
           - target: ADDRESS_BUILD
             ENABLED: "${{ vars.ADDRESS_BUILD_ENABLED }}"
@@ -222,16 +227,7 @@ jobs:
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_CHECK_BUILD_COMMON_CRI_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:         HMRC_CHECK_BUILD_COMMON_CRI_GH_ACTIONS_ROLE_ARN
             SIGNING_PROFILE_NAME:               HMRC_CHECK_BUILD_SIGNING_PROFILE_NAME
-    name: Sign and publish common_cri infrastructure to Build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    env:
-      AWS_REGION: eu-west-2
-    permissions:
-      id-token: write
-      contents: read
     steps:
-
       - name: Checkout code
         if: matrix.ENABLED == 'true'
         uses: actions/checkout@v3
@@ -277,8 +273,8 @@ jobs:
           working-directory: ./out
 
   clean_up:
-    needs: sign_and_publish_common_cri_to_build
     name: Clean up cache
+    needs: sign_and_publish_common_cri_to_build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -287,18 +283,17 @@ jobs:
       id-token: write
       contents: read
     steps:
-
-    - name: Cleanup Cache
-      if: ${{ always() }}
-      run: |
-        gh extension install actions/gh-actions-cache
-
-        REPO=${{ github.repository }}
-        # BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge" # might need this
-        BRANCH="refs/heads/main"
-        set +e
-        echo "Deleting cache..."
-            gh actions-cache delete "${{ github.sha }}" -R $REPO -B $BRANCH --confirm
-        echo "Done"
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cleanup Cache
+        if: ${{ always() }}
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          # BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge" # might need this
+          BRANCH="refs/heads/main"
+          set +e
+          echo "Deleting cache..."
+              gh actions-cache delete "${{ github.sha }}" -R $REPO -B $BRANCH --confirm
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-test-resources.yml
+++ b/.github/workflows/package-test-resources.yml
@@ -29,7 +29,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: test-resources-${{ matrix.environment }}
-    name: ${{ format('Publish to {0} {1}', matrix.environment, matrix.name) }}
+    name: ${{ format('Publish to {0} {1}', matrix.name, matrix.environment) }}
     concurrency:
       group: package-test-resources-${{ matrix.environment }}
       cancel-in-progress: false
@@ -40,16 +40,16 @@ jobs:
       fail-fast: false
       matrix:
         environment: [dev, build]
-        cri: [address, check-hmrc]
+        cri: [ADDRESS, CHECK_HMRC]
         include:
-          - {cri: address, prefix: ADDRESS}
-          - {cri: check-hmrc, prefix: CHECK_HMRC}
+          - {cri: ADDRESS, name: Address}
+          - {cri: CHECK_HMRC, name: "Check HMRC"}
     steps:
       - name: Check deployment enabled
         id: enabled
         if: ${{
           (github.ref_name == 'main' || matrix.environment == 'dev') &&
-          vars[format('{0}_ENABLED', matrix.prefix)] == 'true'
+          vars[format('{0}_ENABLED', matrix.cri)] == 'true'
           }}
         shell: bash
         run: exit 0
@@ -70,13 +70,13 @@ jobs:
         if: ${{ steps.enabled.conclusion == 'success' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars[format('{0}_ROLE_ARN', matrix.prefix)] }}
+          role-to-assume: ${{ vars[format('{0}_ROLE_ARN', matrix.cri)] }}
           aws-region: eu-west-2
 
       - name: Upload to S3
         if: ${{ steps.enabled.conclusion == 'success' }}
         uses: govuk-one-login/devplatform-upload-action@v3.9.2
         with:
-          artifact-bucket-name: ${{ vars[format('{0}_ARTIFACTS_BUCKET_NAME', matrix.prefix)] }}
-          signing-profile-name: ${{ vars[format('{0}_SIGNING_PROFILE_NAME', matrix.prefix)] }}
+          artifact-bucket-name: ${{ vars[format('{0}_ARTIFACTS_BUCKET_NAME', matrix.cri)] }}
+          signing-profile-name: ${{ vars[format('{0}_SIGNING_PROFILE_NAME', matrix.cri)] }}
           working-directory: .aws-sam/build

--- a/.github/workflows/package-test-resources.yml
+++ b/.github/workflows/package-test-resources.yml
@@ -6,10 +6,6 @@ on:
     branches: [main]
     paths: [test-resources/**]
 
-concurrency:
-  group: package-test-resources-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: false
-
 permissions: {}
 
 jobs:
@@ -33,7 +29,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: test-resources-${{ matrix.environment }}
-    name: ${{ format('Publish [{0} | {1}]', matrix.environment, matrix.cri) }}
+    name: ${{ format('Publish to {0} {1}', matrix.environment, matrix.name) }}
+    concurrency:
+      group: package-test-resources-${{ matrix.environment }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -11,11 +11,11 @@ on:
       ipv-core-stub-basic-auth-pwd: { required: true }
       ipv-core-stub-basic-auth-user: { required: true }
 
-permissions: {}
-
 concurrency:
   group: integration-tests-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   run-tests:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -3,13 +3,13 @@ name: Integration tests
 on:
   workflow_call:
     inputs:
-      aws-region: { required: false, type: string }
-      stack-name: { required: true, type: string }
-      stack-outputs: { required: true, type: string }
+      aws-region: {required: false, type: string}
+      stack-name: {required: true, type: string}
+      stack-outputs: {required: true, type: string}
     secrets:
-      api-gateway-api-key: { required: true }
-      ipv-core-stub-basic-auth-pwd: { required: true }
-      ipv-core-stub-basic-auth-user: { required: true }
+      api-gateway-api-key: {required: true}
+      ipv-core-stub-basic-auth-pwd: {required: true}
+      ipv-core-stub-basic-auth-user: {required: true}
 
 concurrency:
   group: integration-tests-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/run-pact-tests-java.yml
+++ b/.github/workflows/run-pact-tests-java.yml
@@ -3,11 +3,11 @@ name: Unit pact tests (Java)
 on:
   workflow_call:
     inputs:
-      CRI_UNDER_TEST: { required: true, type: string }
+      cri-provider: {required: true, type: string}
     secrets:
-      pact-broker-host: { required: true }
-      pact-broker-username: { required: true }
-      pact-broker-password: { required: true }
+      pact-broker-host: {required: true}
+      pact-broker-username: {required: true}
+      pact-broker-password: {required: true}
 
 concurrency:
   group: pact-tests-java-${{ inputs.cri-provider }}-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
@@ -17,7 +17,7 @@ defaults:
   run:
     shell: bash
 
-permissions: { }
+permissions: {}
 
 jobs:
   run-pact-tests:
@@ -51,8 +51,8 @@ jobs:
 
       - name: Run tests
         env:
+          CRI_UNDER_TEST: ${{ inputs.cri-provider }}
           PACT_BROKER_HOST: ${{ secrets.pact-broker-host }}
           PACT_BROKER_USERNAME: ${{ secrets.pact-broker-username }}
           PACT_BROKER_PASSWORD: ${{ secrets.pact-broker-password }}
-          CRI_UNDER_TEST: ${{ inputs.CRI_UNDER_TEST }}
         run: ./gradlew pactTests jacocoTestReport --build-cache --parallel -x spotlessApply -x spotlessCheck

--- a/.github/workflows/run-pact-tests-java.yml
+++ b/.github/workflows/run-pact-tests-java.yml
@@ -9,6 +9,10 @@ on:
       pact-broker-username: { required: true }
       pact-broker-password: { required: true }
 
+concurrency:
+  group: pact-tests-java-${{ inputs.cri-provider }}-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/run-pact-tests-ts.yml
+++ b/.github/workflows/run-pact-tests-ts.yml
@@ -3,11 +3,11 @@ name: Unit pact tests (TypeScript)
 on:
   workflow_call:
     inputs:
-      CRI_UNDER_TEST: { required: true, type: string }
+      cri-provider: {required: true, type: string}
     secrets:
-      pact-broker-host: { required: true }
-      pact-broker-username: { required: true }
-      pact-broker-password: { required: true }
+      pact-broker-host: {required: true}
+      pact-broker-username: {required: true}
+      pact-broker-password: {required: true}
 
 concurrency:
   group: pact-tests-ts-${{ inputs.cri-provider }}-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
@@ -17,7 +17,7 @@ defaults:
   run:
     shell: bash
 
-permissions: { }
+permissions: {}
 
 jobs:
   run-pact-tests:
@@ -25,24 +25,24 @@ jobs:
     runs-on: ubuntu-latest
     environment: development
     steps:
-    - name: Pull repository
-      uses: actions/checkout@v4
+      - name: Pull repository
+        uses: actions/checkout@v4
 
-    - name: Install Node
-      uses: actions/setup-node@v4
-      with:
-        cache: npm
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          cache: npm
 
-    - name: Install dependencies
-      run: npm ci --include-workspace-root
+      - name: Install dependencies
+        run: npm ci --include-workspace-root
 
-    - name: Run tests
-      uses: govuk-one-login/github-actions/node/run-script@e6b6ed890b35904e1be79f7f35ffec983fa4d9db
-      env:
-        CRI_UNDER_TEST: ${{ inputs.CRI_UNDER_TEST }}
-        PACT_BROKER_HOST: ${{ secrets.pact-broker-host }}
-        PACT_BROKER_USERNAME: ${{ secrets.pact-broker-username }}
-        PACT_BROKER_PASSWORD: ${{ secrets.pact-broker-password }}
-      with:
-        working-directory: lambdas
-        script: npm run test:contract:ci
+      - name: Run tests
+        uses: govuk-one-login/github-actions/node/run-script@e6b6ed890b35904e1be79f7f35ffec983fa4d9db
+        env:
+          CRI_UNDER_TEST: ${{ inputs.cri-provider }}
+          PACT_BROKER_HOST: ${{ secrets.pact-broker-host }}
+          PACT_BROKER_USERNAME: ${{ secrets.pact-broker-username }}
+          PACT_BROKER_PASSWORD: ${{ secrets.pact-broker-password }}
+        with:
+          working-directory: lambdas
+          script: npm run test:contract:ci

--- a/.github/workflows/run-pact-tests-ts.yml
+++ b/.github/workflows/run-pact-tests-ts.yml
@@ -9,6 +9,10 @@ on:
       pact-broker-username: { required: true }
       pact-broker-password: { required: true }
 
+concurrency:
+  group: pact-tests-ts-${{ inputs.cri-provider }}-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
- Exclude test resources from the workflow that publishes common lambdas
- Adjust naming and formatting
- Add concurrency to jobs and workflows
