### PR TITLE
OJ-2815: Update TS session-handler to store context

### DIFF
--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -96,6 +96,7 @@ export class SessionLambda implements LambdaInterface {
             state: jwtPayload["state"] as string,
             subject: jwtPayload.sub as string,
             evidenceRequested: jwtPayload["evidence_requested"] as EvidenceRequest,
+            context: jwtPayload["context"] as string,
         };
     }
 

--- a/lambdas/src/services/session-service.ts
+++ b/lambdas/src/services/session-service.ts
@@ -111,6 +111,7 @@ export class SessionService {
                 clientIpAddress: sessionRequest.clientIpAddress,
                 attemptCount: 0,
                 evidenceRequest: sessionRequest.evidenceRequested,
+                context: sessionRequest.context,
             },
         });
         await this.dynamoDbClient.send(putSessionCommand);

--- a/lambdas/src/types/session-request-summary.ts
+++ b/lambdas/src/types/session-request-summary.ts
@@ -9,4 +9,5 @@ export interface SessionRequestSummary {
     clientIpAddress: string | null;
     state: string;
     evidenceRequested?: EvidenceRequest;
+    context?: string;
 }

--- a/lambdas/tests/unit/handlers/session-handler.test.ts
+++ b/lambdas/tests/unit/handlers/session-handler.test.ts
@@ -409,6 +409,37 @@ describe("SessionLambda", () => {
         expect(result.body).toContain("1025: Request failed due to a server error");
     });
 
+    it("should save the session details with the context field", async () => {
+        jest.spyOn(sessionRequestValidator.prototype, "validateJwt").mockReturnValue(
+            new Promise<JWTPayload>((res) =>
+                res({
+                    client_id: "test-client-id",
+                    govuk_signin_journey_id: "test-journey-id",
+                    persistent_session_id: "test-persistent-session-id",
+                    redirect_uri: "test-redirect-uri",
+                    state: "test-state",
+                    sub: "test-sub",
+                    shared_claims: mockPerson,
+                    context: "test-context",
+                } as JWTPayload),
+            ),
+        );
+        const spy = jest.spyOn(sessionService.prototype, "saveSession");
+        await lambdaHandler(mockEvent, {} as Context);
+
+        const expectedSessionRequestSummary = {
+            clientId: "test-client-id",
+            clientIpAddress: "test-client-ip-address",
+            clientSessionId: "test-journey-id",
+            persistentSessionId: "test-persistent-session-id",
+            redirectUri: "test-redirect-uri",
+            state: "test-state",
+            subject: "test-sub",
+            context: "test-context",
+        };
+        expect(spy).toHaveBeenCalledWith(expectedSessionRequestSummary);
+    });
+
     describe("SessionLambda has evidenceRequested", () => {
         const previousCriIdentifier = process.env.CRI_IDENTIFIER as string;
         beforeEach(() => {
@@ -599,6 +630,69 @@ describe("SessionLambda", () => {
                 },
                 "test-session-id",
             );
+        });
+
+        it("should save the session details with the context field but still audit identity_check context", async () => {
+            jest.spyOn(sessionRequestValidator.prototype, "validateJwt").mockReturnValue(
+                new Promise<JWTPayload>((res) =>
+                    res({
+                        client_id: "test-client-id",
+                        govuk_signin_journey_id: "test-journey-id",
+                        persistent_session_id: "test-persistent-session-id",
+                        redirect_uri: "test-redirect-uri",
+                        state: "test-state",
+                        sub: "test-sub",
+                        shared_claims: mockPersonWithSocialSecurityRecord,
+                        evidence_requested: {
+                            scoringPolicy: "gpg45",
+                            strengthScore: 2,
+                            verificationScore: 2,
+                        },
+                        context: "test-context",
+                    } as JWTPayload),
+                ),
+            );
+            const spySaveSession = jest.spyOn(sessionService.prototype, "saveSession");
+            const spyAuditEvent = jest.spyOn(auditService.prototype, "sendAuditEvent");
+
+            await lambdaHandler(mockEvent, {} as Context);
+
+            const expectedSessionRequestSummary = {
+                clientId: "test-client-id",
+                clientIpAddress: "test-client-ip-address",
+                clientSessionId: "test-journey-id",
+                persistentSessionId: "test-persistent-session-id",
+                redirectUri: "test-redirect-uri",
+                state: "test-state",
+                subject: "test-sub",
+                evidenceRequested: {
+                    scoringPolicy: "gpg45",
+                    strengthScore: 2,
+                    verificationScore: 2,
+                },
+                context: "test-context",
+            };
+            expect(spySaveSession).toHaveBeenCalledWith(expectedSessionRequestSummary);
+
+            expect(spyAuditEvent).toHaveBeenCalledWith(AuditEventType.START, {
+                clientIpAddress: "test-client-ip-address",
+                sessionItem: {
+                    sessionId: "test-session-id",
+                    subject: "test-sub",
+                    persistentSessionId: "test-persistent-session-id",
+                    clientSessionId: "test-journey-id",
+                },
+                extensions: {
+                    evidence: [
+                        {
+                            context: "identity_check",
+                        },
+                    ],
+                    evidence_requested: {
+                        verificationScore: 2,
+                    },
+                },
+            });
         });
     });
 


### PR DESCRIPTION
## Proposed changes

### What changed

context can now be included as in the JWT for a session. This now gets context from the JWT and stores it within the session item.

### Why did it change

We want to make the corresponding changes as in the Java lambdas to store context from the JWT.

Note: check-hmrc determines the "context" of a record_check or an identity_check through the presence of the evidence_requested property. This PR allows an actual context property to be included in the JWT and stored in the session item. If this property is used in the future and wants to be included in the audit event, check-hmrc "context" logic may need refactoring. 

### Issue tracking

- [OJ-2815](https://govukverify.atlassian.net/browse/OJ-2815)

## Evidence

Tested with a check-hmrc stack through the core stub.

<img width="1485" alt="Screenshot 2024-10-18 at 16 40 31" src="https://github.com/user-attachments/assets/ef11b5fe-23e7-48e2-ba6d-4ff230004d41">


[OJ-2815]: https://govukverify.atlassian.net/browse/OJ-2815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ