### PR TITLE
OJ-2552: Create "access-token-index-all" index with all attributes projected

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -898,6 +898,12 @@ Resources:
               - "redirectUri"
               - "clientId"
             ProjectionType: "INCLUDE"
+        - IndexName: "access-token-index-all"
+          KeySchema:
+            - AttributeName: "accessToken"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: ALL
         - IndexName: "access-token-index"
           KeySchema:
             - AttributeName: "accessToken"


### PR DESCRIPTION
## Proposed changes

### What changed
Add a new GSI to the SessionTable.

### Why did it change
In the Check HMRC CRI we are currently doing a DynamoDB Scan to query the session table by accessToken. This PR adds a new index `access-token-index-all` that projects all fields so that we can use a DynamoDB Query operation instead of using a Scan to reduce the complexity and cost of using a DynamoDB Scan.

### Issue tracking
- [OJ-2552](https://govukverify.atlassian.net/browse/OJ-2552)



[OJ-2552]: https://govukverify.atlassian.net/browse/OJ-2552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ