### PR TITLE
Updated to version 4 of upload artifact action

### DIFF
--- a/.github/workflows/run-unit-tests-java.yml
+++ b/.github/workflows/run-unit-tests-java.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Archive coverage results
         if: ${{ inputs.coverage-report }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.coverage-artifact }}
           retention-days: 3

--- a/.github/workflows/run-unit-tests-ts.yml
+++ b/.github/workflows/run-unit-tests-ts.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Archive coverage results
         if: ${{ inputs.coverage-report }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.coverage-artifact }}
           path: lambdas/coverage/lcov.info

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -67,7 +67,7 @@ jobs:
           path: ~/.sonar/cache
 
       - name: Get coverage results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.unit-tests-java.outputs.coverage-artifact }}
 

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@cf644c0d66c41259bfe2509852d1211e3f01f44d
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@0739d7e7a19bae3177cf851ae51944bb4dd53565 #30th Jan 2024
         with:
           projectBaseDir: lambdas
           coverage-location: lambdas/coverage


### PR DESCRIPTION
EOL on the 5th December 2024

Also updated version of Sonar Cloud as it needs to use download-artifact v4 as well

https://govukverify.atlassian.net/browse/PSREDEV-1911

## Proposed changes
https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new

### What changed

Updated a GH action

### Why did it change

V3 being EOLed 5th Dec

### Issue tracking
https://govukverify.atlassian.net/browse/PSREDEV-1911
