### PR TITLE
LIME-1384 - Add SnapStart Alias and Permissions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
 		junit                    : "5.10.1",
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
-		cri_common_lib           : "3.2.1"
+		cri_common_lib           : "3.7.0"
 	]
 }
 

--- a/infrastructure/lambda/pre-merge-api.yaml
+++ b/infrastructure/lambda/pre-merge-api.yaml
@@ -67,7 +67,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizationFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizationFunction.Arn}:live/invocations
         passthroughBehavior: "when_no_match"
 
   /authorization-ts:
@@ -175,7 +175,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SessionFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SessionFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"
@@ -238,7 +238,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AccessTokenFunction.Arn}/invocations
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AccessTokenFunction.Arn}:live/invocations
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -96,7 +96,6 @@ Globals:
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
     Timeout: 30 # seconds
-    AutoPublishAlias: live
     Tracing: Active
     MemorySize: !FindInMap [MemorySizeMapping, Environment, !Ref "Environment"]
     Architectures:
@@ -180,6 +179,57 @@ Mappings:
       staging: 7200 # 2 hours
       integration: 7200 # 2 hours
       production: 7200 # 2 hours
+
+  # Java functions only (Enables per cri&env role out)
+  SnapStartMapping:
+    di-ipv-cri-address-api:
+      dev: None
+      build: None
+      staging: None
+      integration: None
+      production: None
+    di-ipv-cri-fraud-api:
+      dev: None
+      build: None
+      staging: None
+      integration: None
+      production: None
+    di-ipv-cri-kbv-api:
+      dev: None
+      build: None
+      staging: None
+      integration: None
+      production: None
+    di-ipv-cri-dl-api:
+      dev: None
+      build: None
+      staging: None
+      integration: None
+      production: None
+    di-ipv-cri-passport-api:
+      dev: None
+      build: None
+      staging: None
+      integration: None
+      production: None
+    di-ipv-cri-toy-api:
+      dev: None
+      build: None
+      staging: None
+      integration: None
+      production: None
+    di-ipv-cri-kbv-hmrc-api:
+      dev: None
+      build: None
+      staging: None
+      integration: None
+      production: None
+    di-ipv-cri-check-hmrc-api:
+      dev: None
+      build: None
+      staging: None
+      integration: None
+      production: None
 
   CriVpcMapping:
     di-ipv-cri-address-api:
@@ -482,6 +532,9 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-session"
           SQS_AUDIT_EVENT_QUEUE_URL:
             Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
+      AutoPublishAlias: live
+      SnapStart:
+        ApplyOn: !FindInMap [SnapStartMapping, !Ref CriIdentifier, !Ref Environment]
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -565,6 +618,7 @@ Resources:
           SQS_AUDIT_EVENT_QUEUE_URL:
             Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
           CRI_IDENTIFIER: !Sub "${CriIdentifier}"
+      AutoPublishAlias: live
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -609,6 +663,7 @@ Resources:
           - src/handlers/session-handler.ts
         External:
           - "@aws-sdk/*"
+
   SessionFunctionTSLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -645,6 +700,9 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-authorization"
+      AutoPublishAlias: live
+      SnapStart:
+        ApplyOn: !FindInMap [SnapStartMapping, !Ref CriIdentifier, !Ref Environment]
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -690,6 +748,7 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-authorizationTS"
+      AutoPublishAlias: live
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -763,6 +822,9 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-access-token"
+      AutoPublishAlias: live
+      SnapStart:
+        ApplyOn: !FindInMap [SnapStartMapping, !Ref CriIdentifier, !Ref Environment]
       Policies:
         - DynamoDBReadPolicy:
             TableName:
@@ -803,6 +865,7 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-access-token-2"
+      AutoPublishAlias: live
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -1328,6 +1391,13 @@ Resources:
       FunctionName: !GetAtt SessionFunction.Arn
       Principal: apigateway.amazonaws.com
 
+  SessionFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref SessionFunction.Alias
+      Principal: apigateway.amazonaws.com
+
   SessionFunctionTSPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -1342,11 +1412,25 @@ Resources:
       FunctionName: !GetAtt AccessTokenFunction.Arn
       Principal: apigateway.amazonaws.com
 
+  AccessTokenFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref AccessTokenFunction.Alias
+      Principal: apigateway.amazonaws.com
+
   AuthorizationFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt AuthorizationFunction.Arn
+      Principal: apigateway.amazonaws.com
+
+  AuthorizationFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref AuthorizationFunction.Alias
       Principal: apigateway.amazonaws.com
 
   AuthorizationFunctionTSPermission:


### PR DESCRIPTION
## Proposed changes

### What changed

	- Non Alias permissions need to be kept until all CRI's migrate to snap-start.
	- SnapStartMapping added to enable a controlled role out per env for each CRI

### Why did it change

Alias add as a technical requirement of snap-start.

SnapStartMapping 
Added to enable snap-start role out only to specific CRI and environments.
And so that greater testing can happen prior to production role-out for each CRI.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1384](https://govukverify.atlassian.net/browse/LIME-1384)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1384]: https://govukverify.atlassian.net/browse/LIME-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ