### PR TITLE
LIME-1437 Enable snap-start for Passport CRI (dev-staging)

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -269,7 +269,7 @@ Mappings:
       production: 0
     di-ipv-cri-passport-api:
       dev: 0
-      build: 1
+      build: 0
       staging: 0
       integration: 0
       production: 0
@@ -320,9 +320,9 @@ Mappings:
       integration: None
       production: None
     di-ipv-cri-passport-api:
-      dev: None
-      build: None
-      staging: None
+      dev: PublishedVersions
+      build: PublishedVersions
+      staging: PublishedVersions
       integration: None
       production: None
     di-ipv-cri-toy-api:


### PR DESCRIPTION
## Proposed changes

### What changed

Enable snap-start for Passport CRI (dev-staging)

### Why did it change

To test snap-start prior to production roll out

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1437](https://govukverify.atlassian.net/browse/LIME-1437)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1437]: https://govukverify.atlassian.net/browse/LIME-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ