### PR TITLE
LIME-1519 Fraud CRI - enable ProvisionedConcurrency on Java Lambdas

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -242,10 +242,10 @@ Mappings:
       production: 0
     di-ipv-cri-fraud-api:
       dev: 0
-      build: 0
-      staging: 0
-      integration: 0
-      production: 0
+      build: 1
+      staging: 1
+      integration: 1
+      production: 1
     di-ipv-cri-kbv-api:
       dev: 0
       build: 0


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enable ProvisionedConcurrency on Java Lambdas for Fraud CRI

### Why did it change

ProvisionedConcurrency is enabled on the main Fraud CRI lambdas but not on the common-api lambdas.

### Issue tracking

- [LIME-1519](https://govukverify.atlassian.net/browse/LIME-1519)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1519]: https://govukverify.atlassian.net/browse/LIME-1519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ