### PR TITLE
BAU: Bump github-actions versions so deprecated actions no longer used

### DIFF
--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -26,7 +26,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: Get stale preview stacks
-        uses: govuk-one-login/github-actions/sam/get-stale-stacks@cf644c0d66c41259bfe2509852d1211e3f01f44d
+        uses: govuk-one-login/github-actions/sam/get-stale-stacks@ca188729ecb0c92e5fe5ae7c024f9894815da3a1
         with:
           threshold-days: 14
           stack-name-filter: preview-common-lambdas
@@ -38,7 +38,7 @@ jobs:
 
       - name: Delete stacks
         if: ${{ env.STACKS != null }}
-        uses: govuk-one-login/github-actions/sam/delete-stacks@cf644c0d66c41259bfe2509852d1211e3f01f44d
+        uses: govuk-one-login/github-actions/sam/delete-stacks@ca188729ecb0c92e5fe5ae7c024f9894815da3a1
         with:
           stack-names: ${{ env.STACKS }}
           verbose: true

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Get stack name
-        uses: govuk-one-login/github-actions/beautify-branch-name@cf644c0d66c41259bfe2509852d1211e3f01f44d
+        uses: govuk-one-login/github-actions/beautify-branch-name@ca188729ecb0c92e5fe5ae7c024f9894815da3a1
         id: get-stack-name
         with:
           usage: Stack name
@@ -29,7 +29,7 @@ jobs:
           verbose: false
 
       - name: Delete stack
-        uses: govuk-one-login/github-actions/sam/delete-stacks@cf644c0d66c41259bfe2509852d1211e3f01f44d
+        uses: govuk-one-login/github-actions/sam/delete-stacks@ca188729ecb0c92e5fe5ae7c024f9894815da3a1
         with:
           stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -47,7 +47,7 @@ jobs:
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build SAM application
-        uses: govuk-one-login/github-actions/sam/build-application@cf644c0d66c41259bfe2509852d1211e3f01f44d
+        uses: govuk-one-login/github-actions/sam/build-application@ca188729ecb0c92e5fe5ae7c024f9894815da3a1
         id: build
         with:
           template: infrastructure/lambda/template.yaml
@@ -70,7 +70,7 @@ jobs:
       stack-outputs: ${{ steps.deploy.outputs.stack-outputs }}
     steps:
       - name: Deploy stack
-        uses: govuk-one-login/github-actions/sam/deploy-stack@cf644c0d66c41259bfe2509852d1211e3f01f44d
+        uses: govuk-one-login/github-actions/sam/deploy-stack@ca188729ecb0c92e5fe5ae7c024f9894815da3a1
         id: deploy
         with:
           sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -98,6 +98,6 @@ jobs:
       security-events: write
     steps:
       - name: Run CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@cf644c0d66c41259bfe2509852d1211e3f01f44d
+        uses: govuk-one-login/github-actions/code-quality/codeql@52a9e8e35980e6bcaf24d88180a61501e6f2605b
         with:
           languages: javascript-typescript


### PR DESCRIPTION
## Proposed changes

### What changed

Some nested actions (upload & download-artifact v3) have been deprecated and were nested inside [govuk-one-login/github-actions](https://github.com/govuk-one-login/github-actions). Updates to use the latest commits for each action using commit `cf644c0d66c41259bfe2509852d1211e3f01f44d`

### Why did it change

Build SAM App failing.
`Error: This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ `

![Screenshot 2025-02-12 at 09 21 35](https://github.com/user-attachments/assets/e467a02e-8837-46df-b160-5b6d40460b71)
