### PR TITLE
OJ-3048: Update sonar action

### DIFF
--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@0739d7e7a19bae3177cf851ae51944bb4dd53565 #30th Jan 2024
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@52a9e8e35980e6bcaf24d88180a61501e6f2605b
         with:
           projectBaseDir: lambdas
           coverage-location: lambdas/coverage


### PR DESCRIPTION
# Proposed changes

### What changed

Update sonar GHA to the latest commit SHA.

### Why did it change

Upstream sonar action is being deprecated.

### Issue tracking

- [OJ-3048](https://govukverify.atlassian.net/browse/OJ-3048)

[OJ-3048]: https://govukverify.atlassian.net/browse/OJ-3048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ