### PR TITLE
OJ-3070: Enable snap-start excluding prod

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -232,7 +232,7 @@ Mappings:
       integration: 0
       production: 0
 
-  # CANNOT be >1 with JavaSnapStart enabled - (Enables per cri&env role out)
+  # CANNOT be >= 1 with JavaSnapStart enabled - (Enables per cri&env role out)
   JavaProvisionedConcurrencyMapping:
     di-ipv-cri-address-api:
       dev: 0
@@ -281,10 +281,10 @@ Mappings:
   # Permitted values : PublishedVersions or None
   JavaSnapStartMapping:
     di-ipv-cri-address-api:
-      dev: None
-      build: None
-      staging: None
-      integration: None
+      dev: PublishedVersions
+      build: PublishedVersions
+      staging: PublishedVersions
+      integration: PublishedVersions
       production: None
     di-ipv-cri-fraud-api:
       dev: None


### PR DESCRIPTION
## Proposed changes

Enable snap-start for Address CRI (dev - integration) to test prior roll out to production

### What changed

Ensured provisioned concurrency is not enabled for Address CRI
Added `PublishedVersions` for dev - integration environment to enable SNAP START

### Why did it change

To test Provisioned Concurrency in non-prod environments


- [OJ-3070](https://govukverify.atlassian.net/browse/OJ-3070)