### PR TITLE
OJ-2331: Add deploy script for test resources stack

### DIFF
--- a/test-resources/deploy.sh
+++ b/test-resources/deploy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+cd "$(dirname "${BASH_SOURCE[0]}")"
+set -eu
+
+stack_name="${1:-}"
+
+if ! [[ "$stack_name" ]]; then
+  [[ $(aws sts get-caller-identity --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user="${BASH_REMATCH[1]}" || exit
+  stack_name="$user-test-resources"
+  echo "» Using stack name '$stack_name'"
+fi
+
+sam validate -t infrastructure/template.yaml
+sam validate -t infrastructure/template.yaml --lint
+
+sam build -t infrastructure/template.yaml --cached --parallel
+
+sam deploy --stack-name "$stack_name" \
+  --no-fail-on-empty-changeset \
+  --no-confirm-changeset \
+  --resolve-s3 \
+  --s3-prefix "$stack_name" \
+  --region "${AWS_REGION:-eu-west-2}" \
+  --capabilities CAPABILITY_IAM \
+  --tags \
+  cri:component=ipv-cri-common-test-harness \
+  cri:deployment-source=manual \
+  cri:stack-type=dev \
+  --parameter-overrides \
+  Environment=dev 


### PR DESCRIPTION
## Proposed changes

### What changed

Added `deploy.sh` for test resources stack

### Why did it change

Easier deployments of localdev test-resources stacks. 

### Issue tracking

- [OJ-2331](https://govukverify.atlassian.net/browse/OJ-2331)


[OJ-2331]: https://govukverify.atlassian.net/browse/OJ-2331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ