### PR TITLE
OJ-3113: Fix wrong client assert type

### DIFF
--- a/lambdas/src/services/token-request-validator.ts
+++ b/lambdas/src/services/token-request-validator.ts
@@ -28,7 +28,7 @@ export class AccessTokenRequestValidator {
             !client_assertion_type ||
             client_assertion_type !== "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
         ) {
-            throw new InvalidRequestError("Invalid grant_type parameter");
+            throw new InvalidRequestError("Invalid client_assertion_type parameter");
         }
 
         return { grant_type, code, redirectUri, client_assertion_type, client_assertion };

--- a/lambdas/tests/unit/services/token-request-validator.test.ts
+++ b/lambdas/tests/unit/services/token-request-validator.test.ts
@@ -21,7 +21,7 @@ describe("token-request-validator.ts", () => {
         it("should throw when the client_assertion_type is not valid", function () {
             const tokenRequestBody = `code=${code}&redirect_uri=${redirect_uri}&client_assertion=${client_assertion}&client_assertion_type=test&grant_type=${grant_type}`;
             expect(() => accessTokenRequestValidator.validatePayload(tokenRequestBody)).toThrow(
-                "Invalid grant_type parameter",
+                "Invalid client_assertion_type parameter",
             );
         });
 


### PR DESCRIPTION
### What changed

Thanks to Coral Gage, there was a wrong error being thrown when the client_assertion_type is not present
or is of the wrong value
