### PR TITLE
OJ-3120: Implement DequeueEvents condition

### DIFF
--- a/test-resources/deploy.sh
+++ b/test-resources/deploy.sh
@@ -25,6 +25,6 @@ sam deploy --stack-name "$stack_name" \
   --tags \
   cri:component=ipv-cri-common-test-harness \
   cri:deployment-source=manual \
-  cri:stack-type=dev \
+  cri:stack-type=localdev \
   --parameter-overrides \
-  Environment=dev 
+  Environment=localdev 

--- a/test-resources/infrastructure/samconfig.toml
+++ b/test-resources/infrastructure/samconfig.toml
@@ -17,9 +17,9 @@ resolve_s3 = true
 tags = [
     "cri:component=ipv-cri-common-test-harness",
     "cri:deployment-source=manual",
-    "cri:stack-type=dev",
+    "cri:stack-type=localdev",
 ]
 
 parameter_overrides = [
-    "Environment=dev",
+    "Environment=localdev",
 ]

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -30,14 +30,17 @@ Parameters:
 Mappings:
   TestHarnessUrl:
       di-ipv-cri-check-hmrc-api:
+        localdev: review-hc.dev.account.gov.uk
         dev: review-hc.dev.account.gov.uk
         build: review-hc.build.account.gov.uk
         staging: review-hc.staging.account.gov.uk
       di-ipv-cri-address-api:
+        localdev: review-a.dev.account.gov.uk
         dev: review-a.dev.account.gov.uk
         build: review-a.build.account.gov.uk
         staging: review-a.staging.account.gov.uk
       di-ipv-cri-kbv-api:
+        localdev: review-k.dev.account.gov.uk
         dev: review-k.dev.account.gov.uk
         build: review-k.build.account.gov.uk
         staging: review-k.staging.account.gov.uk
@@ -45,6 +48,7 @@ Mappings:
 Conditions:
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]
+  DequeueEvents: !Not [!Equals [!Ref Environment, localdev]]
 
 Globals:
   Function:
@@ -125,9 +129,9 @@ Resources:
         AuditSQSEvent:
           Type: SQS
           Properties:
+            Enabled: !If [DequeueEvents, true, false]
             Queue:
               Fn::ImportValue: !Sub "${TxmaStackName}-AuditEventQueueArn"
-            Enabled: true
             FunctionResponseTypes:
               - ReportBatchItemFailures
 


### PR DESCRIPTION
## Proposed changes

### What changed

 Implement DequeueEvents condition

### Why did it change

So that local dev stacks don't dequeue events from the main txma event queue that is used for pre-merge testing

### Screenshots

![image](https://github.com/user-attachments/assets/aa7685cd-b402-4b9b-9acd-7b59fa93947e)

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3120](https://govukverify.atlassian.net/browse/OJ-3120)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->



[OJ-3120]: https://govukverify.atlassian.net/browse/OJ-3120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ