### PR TITLE
OJ-2331: Add start endpoint to headless-core-stub

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -112,7 +112,7 @@
     },
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": []
+      "pattern": ["test-resources/headless-core-stub/utils/tests/test-data.ts"]
     },
     {
       "path": "detect_secrets.filters.regex.should_exclude_secret",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3635,10 +3635,14 @@
       }
     },
     "node_modules/@govuk-one-login/data-vocab": {
-      "version": "1.9.3"
+      "version": "1.9.3",
+      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab/1.9.3/fa6de901e9fecc985fca4d91cd9f39e69419bc63",
+      "integrity": "sha512-pOwhj9gYkCEci5qRvlXGFT1e/Li250R9+P4kRP9CliEOxTs1GoAJcDUNs60ZKOgSpL24xOQ4NE09uSn6HL5nPw=="
     },
     "node_modules/@govuk-one-login/data-vocab-schemas": {
-      "version": "1.9.3"
+      "version": "1.9.3",
+      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab-schemas/1.9.3/aa10a6234ec7bf3a4c039ef238cd46f54a71d126",
+      "integrity": "sha512-oz4dhGInNFa92kb43tTcHiu9hGoUQSCVsHtB/hia2I5C9m2+zw0kPgWZqX/gVVSMpyDYhRQ5vqRu0MJHyPRIOQ=="
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.12.5",
@@ -4383,6 +4387,19 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@middy/core": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.2.8.tgz",
+      "integrity": "sha512-cz3nec4THgolPk3iK4JCxzXSJXudm0QlUFNRYl8JpcdY1vYSnlPuDZo6aKEFbh8+A5gBs04cGwMcnH/GTtNX6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/willfarrell"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -5066,8 +5083,8 @@
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -5079,6 +5096,32 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.0.1",
@@ -5765,6 +5808,21 @@
       "version": "1.2.0",
       "license": "MIT"
     },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "dev": true,
@@ -6055,6 +6113,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "dev": true,
@@ -6223,6 +6320,17 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
+      "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinon": "^17.0.3",
+        "sinon": "^18.0.1",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/aws-sdk/node_modules/uuid": {
@@ -7775,8 +7883,8 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -7829,6 +7937,22 @@
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
@@ -10544,8 +10668,8 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -10562,6 +10686,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -10655,6 +10785,13 @@
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
+      "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isfunction": {
@@ -10858,6 +10995,37 @@
       "version": "1.0.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
@@ -11696,6 +11864,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-in-the-middle": {
       "version": "7.5.0",
       "license": "MIT",
@@ -12033,6 +12210,63 @@
       "version": "3.0.7",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sinon": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -12470,8 +12704,8 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "engines": {
         "node": ">=4"
       }
@@ -12950,6 +13184,10 @@
         "@aws-sdk/client-ssm": "3.772.0",
         "@govuk-one-login/data-vocab": "1.9.3",
         "@govuk-one-login/data-vocab-schemas": "1.9.3",
+        "@middy/core": "4.2.8",
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
+        "aws-sdk-client-mock": "4.1.0",
         "ecdsa-sig-formatter": "1.0.11",
         "esbuild": "0.25.1",
         "jose": "5.10.0"
@@ -12982,8 +13220,11 @@
       "devDependencies": {}
     },
     "test-resources/headless-core-stub/lambdas/start": {
-      "name": "headless-core-stub-start",
-      "devDependencies": {}
+      "name": "headless-core-stub-start"
+    },
+    "test-resources/headless-core-stub/lambdas/utils": {
+      "name": "headless-core-stub-utils",
+      "extraneous": true
     },
     "test-resources/node_modules/@aws-lambda-powertools/parameters": {
       "version": "2.16.0",
@@ -13047,6 +13288,22 @@
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
+      }
+    },
+    "test-resources/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "test-resources/node_modules/esbuild": {
@@ -13116,6 +13373,7 @@
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
       "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }

--- a/test-resources/headless-core-stub/README.md
+++ b/test-resources/headless-core-stub/README.md
@@ -1,1 +1,106 @@
 # Headless Core Stub
+
+## /start
+
+This endpoint will generate an encrypted JWT that can be used to start a session in a CRI. You can pass in a JSON body to override the values of the JWT Claims Set, or if you pass in an empty JSON object it will generate with default values. 
+
+A full example of top level field overrides can be seen below. For shared_claims and evidence_requested there are more nested fields you can provide. 
+
+It is recommended to not provide overwrites for most fields. For example, time based fields - These should only be overridden if you want to test how a CRI handles expired JWTs etc.
+
+```
+{
+    "iss": "https://localhost.gov.uk",
+    "sub": "urn:fdc:gov.uk:abcdevg",
+    "aud": "https://review-a.dev.account.gov.uk",
+    "iat": 1,
+    "exp": 2,
+    "nbf": 1,
+    "response_type": "code",
+    "client_id": "ipv-core-stub-aws-headless",
+    "redirect_uri": "https://localhost.gov.uk/callback",
+    "state": "abc",
+    "govuk_signin_journey_id": "abc",
+    "shared_claims": {
+        "address": [
+            {
+                "addressLocality": "LONDON",
+                "buildingNumber": "10",
+                "postalCode": "SW1A 2AA",
+                "streetName": "DOWNING STREET",
+                "validFrom": "2020-01-01"
+            }
+        ],
+        "birthDate": [
+            {
+                "value": "1990-01-01"
+            }
+        ],
+        "name": [
+            {
+                "nameParts": [
+                    {
+                        "type": "GivenName",
+                        "value": "JOE"
+                    },
+                    {
+                        "type": "FamilyName",
+                        "value": "BLOGGS"
+                    }
+                ]
+            }
+        ]
+    },
+    "evidence_requested": {
+        "scoringPolicy": "gpg45",
+        "strengthScore": 2,
+        "verificationScore": 2
+    },
+    "context": "cri_context"
+}
+```
+
+If shared_claims is not overridden, the default will be;
+
+```
+{
+    name: [
+        {
+            nameParts: [
+                {
+                    type: "GivenName",
+                    value: "KENNETH",
+                },
+                {
+                    type: "FamilyName",
+                    value: "DECERQUEIRA",
+                },
+            ],
+        },
+    ],
+    birthDate: [
+        {
+            value: "1965-07-08",
+        },
+    ],
+    address: [
+        {
+            buildingNumber: "8",
+            streetName: "HADLEY ROAD",
+            addressLocality: "BATH",
+            postalCode: "BA2 5AA",
+            validFrom: "2021-01-01",
+        },
+    ],
+};
+```
+### Configuration
+
+This stack will need to be deployed into an account with a 'core-infrastructure' stack, as it requires the `core-infrastructure-CriDecryptionKey1Id`
+
+It requires a (test) JWK private key as stored in an SSM param at `/test-resources/ipv-core-stub-aws-headless/privateSigningKey`
+
+If you are planning to use default values for `aud`, `iss`, `redirect_uri`, all of these will need SSM parameters at;   
+`/${COMMON_LAMBDAS_STACK_NAME}/clients/ipv-core-stub-aws-headless/jwtAuthentication/audience`  
+`/${COMMON_LAMBDAS_STACK_NAME}/clients/ipv-core-stub-aws-headless/jwtAuthentication/issuer`   
+`/${COMMON_LAMBDAS_STACK_NAME}/clients/ipv-core-stub-aws-headless/jwtAuthentication/redirectUri`   

--- a/test-resources/headless-core-stub/lambdas/start/package.json
+++ b/test-resources/headless-core-stub/lambdas/start/package.json
@@ -4,10 +4,10 @@
     "scripts": {
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
-        "unit": "jest",
+        "unit": "export POWERTOOLS_DEV=true && jest --silent",
+        "unit:logs": "jest --silent --runInBand",
         "test": "npm run unit --",
         "compile": "tsc"
     },
-    "dependencies": {},
-    "devDependencies": {}
+    "dependencies": {}
 }

--- a/test-resources/headless-core-stub/lambdas/start/src/errors/error-response.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/errors/error-response.ts
@@ -1,0 +1,18 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { HeadlessCoreStubError } from "./headless-core-stub-error";
+
+export const handleErrorResponse = (err: unknown, logger: Logger) => {
+    err instanceof Error ? logger.error(err.message, err) : logger.error("Unknown error caught");
+
+    if (err instanceof HeadlessCoreStubError) {
+        return {
+            statusCode: err.status,
+            body: JSON.stringify({ message: err.message }),
+        };
+    }
+
+    return {
+        statusCode: 500,
+        body: JSON.stringify({ message: "Server error" }),
+    };
+};

--- a/test-resources/headless-core-stub/lambdas/start/src/errors/headless-core-stub-error.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/errors/headless-core-stub-error.ts
@@ -1,0 +1,9 @@
+export class HeadlessCoreStubError extends Error {
+    status: number;
+
+    constructor(message: string, status: number) {
+        super(message);
+        this.status = status;
+        this.name = this.constructor.name;
+    }
+}

--- a/test-resources/headless-core-stub/lambdas/start/src/services/jwt-claims-set-service.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/services/jwt-claims-set-service.ts
@@ -1,0 +1,110 @@
+import { IssuerAuthorizationRequestSchema } from "@govuk-one-login/data-vocab-schemas";
+import { IssuerAuthorizationRequestClass } from "@govuk-one-login/data-vocab/credentials";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { v4 as uuidv4 } from "uuid";
+import { HeadlessCoreStubError } from "../errors/headless-core-stub-error";
+import { ClaimsSetOverrides } from "../types/claims-set-overrides";
+import { JWTClaimsSet } from "../types/jwt-claims-set";
+import { logger } from "../start-handler";
+
+export const parseJwtClaimsSetOverrides = (body: string | null): ClaimsSetOverrides => {
+    try {
+        const claimsSetOverrides = body ? JSON.parse(body) : {};
+        if (!claimsSetOverrides.client_id) {
+            claimsSetOverrides.client_id = "ipv-core-stub-aws-headless";
+        }
+        return claimsSetOverrides;
+    } catch (e) {
+        throw new HeadlessCoreStubError("Body is not valid JSON", 400);
+    }
+};
+
+export const generateJwtClaimsSet = async (overrides: ClaimsSetOverrides, ssmParameters: Record<string, string>) => {
+    const audience = overrides.aud || ssmParameters["audience"];
+    const issuer = overrides.iss || ssmParameters["issuer"];
+    const redirectUri = overrides.redirect_uri || ssmParameters["redirectUri"];
+
+    const now = Date.now();
+    return {
+        iss: issuer,
+        sub: overrides.sub || "urn:fdc:gov.uk:" + uuidv4(),
+        aud: audience,
+        iat: overrides.iat || msToSeconds(now),
+        exp: overrides.exp || msToSeconds(now + 5 * 60 * 1000),
+        nbf: overrides.nbf || msToSeconds(now - 1),
+        response_type: overrides.response_type || "code",
+        client_id: overrides.client_id,
+        redirect_uri: redirectUri,
+        state: overrides.state || uuidv4(),
+        govuk_signin_journey_id: overrides.govuk_signin_journey_id || uuidv4(),
+        shared_claims: overrides.shared_claims != null ? overrides.shared_claims : defaultClaims,
+        ...(overrides.evidence_requested && { evidence_requested: overrides.evidence_requested }),
+        ...(overrides.context && { context: overrides.context }),
+    } as JWTClaimsSet;
+};
+
+export const validateClaimsSet = (claimsSet: JWTClaimsSet) => {
+    //Current data-vocab schemas do not exactly match what our CRIs so we have to validate context manually and add scope and nonce
+    const claimsSetCopy = { ...claimsSet };
+    if (claimsSetCopy.context) {
+        if (typeof claimsSetCopy.context !== "string") {
+            logger.error("Invalid context field");
+            throw new HeadlessCoreStubError("Claims set failed validation", 400);
+        }
+        delete claimsSetCopy.context;
+    }
+    const dataVocabClaimsSet: IssuerAuthorizationRequestClass = { ...claimsSetCopy, scope: "", nonce: "" };
+
+    const ajv = new Ajv({ allErrors: true });
+    addFormats(ajv);
+    const validateCredential = ajv
+        .addSchema(IssuerAuthorizationRequestSchema)
+        .compile(IssuerAuthorizationRequestSchema);
+
+    if (!validateCredential(dataVocabClaimsSet)) {
+        const errorMessages: string[] = [];
+        if (validateCredential.errors) {
+            logger.error(JSON.stringify(validateCredential.errors));
+            validateCredential.errors?.forEach((error) => {
+                errorMessages.push(error.instancePath + " - " + error.message);
+            });
+        }
+
+        const errorDetails = errorMessages?.length ? ": " + errorMessages.join(", ") : "";
+        throw new HeadlessCoreStubError("Claims set failed validation" + errorDetails, 400);
+    }
+};
+
+const msToSeconds = (ms: number) => Math.round(ms / 1000);
+
+const defaultClaims = {
+    name: [
+        {
+            nameParts: [
+                {
+                    type: "GivenName",
+                    value: "KENNETH",
+                },
+                {
+                    type: "FamilyName",
+                    value: "DECERQUEIRA",
+                },
+            ],
+        },
+    ],
+    birthDate: [
+        {
+            value: "1965-07-08",
+        },
+    ],
+    address: [
+        {
+            buildingNumber: "8",
+            streetName: "HADLEY ROAD",
+            addressLocality: "BATH",
+            postalCode: "BA2 5AA",
+            validFrom: "2021-01-01",
+        },
+    ],
+};

--- a/test-resources/headless-core-stub/lambdas/start/src/services/signing-service.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/services/signing-service.ts
@@ -1,0 +1,38 @@
+import { GetPublicKeyCommand, KMSClient } from "@aws-sdk/client-kms";
+import { CompactEncrypt, importSPKI, KeyLike } from "jose";
+import { HeadlessCoreStubError } from "../errors/headless-core-stub-error";
+
+const kmsClient = new KMSClient({ region: "eu-west-2" });
+
+let cachedPublicKey: KeyLike | undefined;
+
+export const getPublicEncryptionKey = async () => {
+    if (cachedPublicKey) {
+        return cachedPublicKey;
+    }
+
+    const decryptionKeyId = process.env.DECRYPTION_KEY_ID;
+    if (!decryptionKeyId) {
+        throw new HeadlessCoreStubError("Decryption key ID not present", 500);
+    }
+
+    const data = await kmsClient.send(new GetPublicKeyCommand({ KeyId: decryptionKeyId }));
+    if (!data?.PublicKey) {
+        throw new HeadlessCoreStubError("Unable to retrieve public encryption key", 500);
+    }
+
+    const base64PublicKey = Buffer.from(data.PublicKey).toString("base64");
+    const header = "-----BEGIN PUBLIC KEY-----";
+    const footer = "-----END PUBLIC KEY-----";
+    const value = base64PublicKey.match(/.{1,64}/g)?.join("\n");
+    const publicKeyPem = `${header}\n${value}\n${footer}`;
+
+    cachedPublicKey = await importSPKI(publicKeyPem, "RS256");
+    return cachedPublicKey;
+};
+
+export const encryptSignedJwt = (signedJwt: string, publicEncryptionKey: KeyLike) => {
+    return new CompactEncrypt(new TextEncoder().encode(signedJwt))
+        .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM" })
+        .encrypt(publicEncryptionKey);
+};

--- a/test-resources/headless-core-stub/lambdas/start/src/start-handler.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/start-handler.ts
@@ -1,13 +1,53 @@
 import type { LambdaInterface } from "@aws-lambda-powertools/commons/types";
+import { Logger } from "@aws-lambda-powertools/logger";
+import { injectLambdaContext } from "@aws-lambda-powertools/logger/middleware";
+import middy from "@middy/core";
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
+import { JWK, JWTPayload, KeyLike } from "jose";
+import { signJwt } from "../../../utils/src/crypto/signer";
+import { ClientConfiguration } from "../../../utils/src/services/client-configuration";
+import { handleErrorResponse } from "./errors/error-response";
+import { generateJwtClaimsSet, parseJwtClaimsSetOverrides, validateClaimsSet } from "./services/jwt-claims-set-service";
+import { encryptSignedJwt, getPublicEncryptionKey } from "./services/signing-service";
+import { ClaimsSetOverrides } from "./types/claims-set-overrides";
+import { JWTClaimsSet } from "./types/jwt-claims-set";
+
+export const logger = new Logger();
 
 export class StartLambdaHandler implements LambdaInterface {
-    async handler(): Promise<{ status: string; body: string }> {
-        return {
-            status: "200",
-            body: "Hello start",
-        };
+    async handler(event: APIGatewayProxyEvent, _context: Context): Promise<APIGatewayProxyResult> {
+        try {
+            const jwtClaimsSetOverrides: ClaimsSetOverrides = parseJwtClaimsSetOverrides(event?.body);
+
+            const ssmParameters = await ClientConfiguration.getConfig(jwtClaimsSetOverrides.client_id);
+
+            const jwtClaimsSet: JWTClaimsSet = await generateJwtClaimsSet(jwtClaimsSetOverrides, ssmParameters);
+
+            validateClaimsSet(jwtClaimsSet);
+
+            const signingKey: JWK = JSON.parse(ssmParameters["privateSigningKey"]);
+
+            const signedJwt = await signJwt(jwtClaimsSet as JWTPayload, signingKey);
+
+            const publicEncryptionKey: KeyLike = await getPublicEncryptionKey();
+
+            const encryptedSignedJwt = await encryptSignedJwt(signedJwt, publicEncryptionKey);
+
+            return Promise.resolve({
+                statusCode: 200,
+                body: JSON.stringify({
+                    request: encryptedSignedJwt,
+                    client_id: jwtClaimsSet.client_id,
+                }),
+            });
+        } catch (err: unknown) {
+            return handleErrorResponse(err, logger);
+        }
     }
 }
 
 const handlerClass = new StartLambdaHandler();
-export const lambdaHandler = handlerClass.handler.bind(handlerClass);
+
+export const lambdaHandler = middy(handlerClass.handler.bind(handlerClass)).use(
+    injectLambdaContext(logger, { clearState: true }),
+);

--- a/test-resources/headless-core-stub/lambdas/start/src/types/claims-set-overrides.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/types/claims-set-overrides.ts
@@ -1,0 +1,18 @@
+import { EvidenceRequestedClass, PersonExtendedMatchingClass } from "@govuk-one-login/data-vocab/credentials";
+
+export interface ClaimsSetOverrides {
+    client_id: string;
+    iss?: string;
+    sub?: string;
+    aud?: string;
+    iat?: number;
+    exp?: number;
+    nbf?: number;
+    response_type?: string;
+    redirect_uri?: string;
+    state?: string;
+    govuk_signin_journey_id?: string;
+    shared_claims?: PersonExtendedMatchingClass;
+    evidence_requested?: EvidenceRequestedClass;
+    context?: string;
+}

--- a/test-resources/headless-core-stub/lambdas/start/src/types/jwt-claims-set.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/types/jwt-claims-set.ts
@@ -1,0 +1,18 @@
+import { EvidenceRequestedClass, PersonExtendedMatchingClass } from "@govuk-one-login/data-vocab/credentials";
+
+export type JWTClaimsSet = {
+    iss: string;
+    sub: string;
+    aud: string;
+    iat: number;
+    exp: number;
+    nbf: number;
+    response_type: string;
+    client_id: string;
+    redirect_uri: string;
+    state: string;
+    govuk_signin_journey_id: string;
+    shared_claims?: PersonExtendedMatchingClass;
+    evidence_requested?: EvidenceRequestedClass;
+    context?: string;
+};

--- a/test-resources/headless-core-stub/lambdas/start/tests/errors/error-response.test.ts
+++ b/test-resources/headless-core-stub/lambdas/start/tests/errors/error-response.test.ts
@@ -1,0 +1,34 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { handleErrorResponse } from "../../src/errors/error-response";
+import { HeadlessCoreStubError } from "../../src/errors/headless-core-stub-error";
+
+describe("error-response", () => {
+    const logger = new Logger();
+    jest.spyOn(logger, "error");
+
+    it("returns error with message on 400 HeadlessCoreStubError", () => {
+        const error = new HeadlessCoreStubError("Custom error", 400);
+        const result = handleErrorResponse(error, logger);
+        expect(result).toEqual({ body: '{"message":"Custom error"}', statusCode: 400 });
+        expect(logger.error).toHaveBeenCalledWith(error.message, error);
+    });
+
+    it("returns server error on 500 HeadlessCoreStubError", () => {
+        const error = new HeadlessCoreStubError("Custom error", 500);
+        const result = handleErrorResponse(error, logger);
+        expect(result).toEqual({ body: '{"message":"Custom error"}', statusCode: 500 });
+        expect(logger.error).toHaveBeenCalledWith("Custom error", error);
+    });
+
+    it("returns 500 on Error", () => {
+        const error = new Error();
+        const result = handleErrorResponse(error, logger);
+        expect(result).toEqual({ body: '{"message":"Server error"}', statusCode: 500 });
+        expect(logger.error).toHaveBeenCalledWith(error.message, error);
+    });
+
+    it("returns 500 on null error", () => {
+        const result = handleErrorResponse(null, logger);
+        expect(result).toEqual({ body: '{"message":"Server error"}', statusCode: 500 });
+    });
+});

--- a/test-resources/headless-core-stub/lambdas/start/tests/services/jwt-claims-set-service.test.ts
+++ b/test-resources/headless-core-stub/lambdas/start/tests/services/jwt-claims-set-service.test.ts
@@ -1,0 +1,175 @@
+import { validate as isValidUUID } from "uuid";
+import { HeadlessCoreStubError } from "../../src/errors/headless-core-stub-error";
+import {
+    generateJwtClaimsSet,
+    parseJwtClaimsSetOverrides,
+    validateClaimsSet,
+} from "../../src/services/jwt-claims-set-service";
+import { ClaimsSetOverrides } from "../../src/types/claims-set-overrides";
+import { TestData } from "../../../../utils/tests/test-data";
+
+describe("jwt-claims-set-service", () => {
+    describe("parseJwtClaimsSetOverrides", () => {
+        const expectedDefaultOverrides: ClaimsSetOverrides = { client_id: "ipv-core-stub-aws-headless" };
+
+        it("returns ClaimsSetOverrides with default client_id when overrides empty", async () => {
+            const result = parseJwtClaimsSetOverrides(JSON.stringify({}));
+            expect(result).toEqual(expectedDefaultOverrides);
+        });
+
+        it("returns ClaimsSetOverrides with default client_id when overrides empty null", async () => {
+            const result = parseJwtClaimsSetOverrides(null);
+            expect(result).toEqual(expectedDefaultOverrides);
+        });
+
+        it("should return empty overrides when body is empty", async () => {
+            const result = parseJwtClaimsSetOverrides("");
+            expect(result).toEqual(expectedDefaultOverrides);
+        });
+
+        it("returns ClaimsSetOverrides with overidden client_id when client_id set", async () => {
+            const result = parseJwtClaimsSetOverrides(JSON.stringify({ client_id: "a-different-client-id" }));
+            expect(result).toEqual({ client_id: "a-different-client-id" });
+        });
+
+        it("throws error with 400 when invalid JSON", async () => {
+            expect(() => {
+                parseJwtClaimsSetOverrides("{");
+            }).toThrow(new HeadlessCoreStubError("Body is not valid JSON", 400));
+        });
+
+        it("returns fully populated ClaimsSetOverrides", async () => {
+            const overrides = {
+                iss: "unit.test.mock",
+                sub: "unit.test.mock",
+                aud: "unit.test.mock",
+                iat: 100,
+                exp: 100,
+                nbf: 100,
+                response_type: "unit.test.mock",
+                client_id: "unit.test.mock",
+                redirect_uri: "unit.test.mock",
+                state: "unit.test.mock",
+                govuk_signin_journey_id: "unit.test.mock",
+                shared_claims: {
+                    address: [
+                        {
+                            addressCountry: "GB",
+                        },
+                    ],
+                },
+                evidence_requested: { verificationScore: 1 },
+                context: "unit.test.mock",
+            };
+
+            const body = JSON.stringify(overrides);
+            const result = parseJwtClaimsSetOverrides(body);
+
+            expect(result).toEqual(overrides);
+        });
+    });
+
+    describe("generateJwtClaimsSet", () => {
+        it("returns a JwtClaimsSet", async () => {
+            const ssmParameters: Record<string, string> = {
+                audience: "https://localhost.com",
+                issuer: "https://localhost.com",
+                redirectUri: "https://localhost.com/callback",
+            };
+
+            const overrides: ClaimsSetOverrides = {
+                client_id: "ipv-core-stub-aws-headless",
+                govuk_signin_journey_id: "d6e00a9b-d66a-4572-b331-318edf307eca",
+                iat: 1742384945,
+                exp: 1742385244,
+                nbf: 1742384945,
+                state: "b72b0ac6-4038-44e1-904c-f1e07832f266",
+                sub: "urn:fdc:gov.uk:a9fb8e38-0458-4dc0-8bec-2662709cb240",
+            };
+
+            const result = await generateJwtClaimsSet(overrides, ssmParameters);
+
+            expect(result).toEqual(TestData.jwtClaimsSet);
+        });
+
+        it("returns a JwtClaimsSet with default dynamic values", async () => {
+            const ssmParameters: Record<string, string> = {
+                audience: "https://localhost.com",
+                issuer: "https://localhost.com",
+                redirectUri: "https://localhost.com/callback",
+            };
+
+            const overrides: ClaimsSetOverrides = { client_id: "ipv-core-stub-aws-headless" };
+
+            const before = Math.round(Date.now() / 1000);
+            const jwtClaimsSet = await generateJwtClaimsSet(overrides, ssmParameters);
+            const after = Math.round(Date.now() / 1000);
+            expect(isValidUUID(jwtClaimsSet.govuk_signin_journey_id || "")).toBeTruthy();
+            expect(isValidUUID(jwtClaimsSet.state || "")).toBeTruthy();
+            expect(jwtClaimsSet.iat && jwtClaimsSet.iat >= before && jwtClaimsSet.iat <= after);
+            expect(jwtClaimsSet.nbf && jwtClaimsSet.nbf <= after);
+            expect(jwtClaimsSet.exp && jwtClaimsSet.exp >= after);
+            let url;
+            try {
+                url = new URL(jwtClaimsSet.sub || "");
+            } catch (_) {
+                return false;
+            }
+            expect(url).toBeTruthy();
+        });
+
+        it("returns a JwtClaimsSet with overridden aud, issuer, redirect", async () => {
+            const ssmParameters: Record<string, string> = {
+                audience: "https://localhost",
+                issuer: "https://localhost",
+                redirectUri: "https://localhost/callback",
+            };
+
+            const overrides: ClaimsSetOverrides = {
+                client_id: "ipv-core-stub-aws-headless",
+                aud: "https://overridden",
+                iss: "https://overridden",
+                redirect_uri: "https://overridden/callback",
+            };
+
+            const jwtClaimsSet = await generateJwtClaimsSet(overrides, ssmParameters);
+
+            expect(jwtClaimsSet.aud).toEqual("https://overridden");
+            expect(jwtClaimsSet.iss).toEqual("https://overridden");
+            expect(jwtClaimsSet.redirect_uri).toEqual("https://overridden/callback");
+        });
+    });
+
+    describe("validateClaimsSet", () => {
+        it("is valid", async () => {
+            expect(() => validateClaimsSet(TestData.jwtClaimsSet)).not.toThrow();
+        });
+
+        it("is invalid", async () => {
+            const invalidClaimsSet = { ...TestData.jwtClaimsSet };
+            invalidClaimsSet.iss = "";
+            expect(() => validateClaimsSet(invalidClaimsSet)).toThrow(
+                new HeadlessCoreStubError('Claims set failed validation: /iss - must match format "uri"', 400),
+            );
+        });
+
+        it("does not delete context from claim set", async () => {
+            const claimsSet = { ...TestData.jwtClaimsSet };
+            claimsSet.context = "Test";
+            expect(() => validateClaimsSet(claimsSet)).not.toThrow();
+            expect(claimsSet.context).toEqual("Test");
+        });
+
+        it("formats error message correctly", async () => {
+            const invalidClaimsSet = { ...TestData.jwtClaimsSet };
+            invalidClaimsSet.iss = "";
+            invalidClaimsSet.aud = "";
+            expect(() => validateClaimsSet(invalidClaimsSet)).toThrow(
+                new HeadlessCoreStubError(
+                    'Claims set failed validation: /aud - must match format "uri", /iss - must match format "uri"',
+                    400,
+                ),
+            );
+        });
+    });
+});

--- a/test-resources/headless-core-stub/lambdas/start/tests/services/signing-service.test.ts
+++ b/test-resources/headless-core-stub/lambdas/start/tests/services/signing-service.test.ts
@@ -1,0 +1,83 @@
+import { clearCaches } from "@aws-lambda-powertools/parameters";
+import { GetPublicKeyCommand, KMSClient } from "@aws-sdk/client-kms";
+import { mockClient } from "aws-sdk-client-mock";
+import { generateKeyPairSync } from "crypto";
+import { HeadlessCoreStubError } from "../../src/errors/headless-core-stub-error";
+import { encryptSignedJwt, getPublicEncryptionKey } from "../../src/services/signing-service";
+import { TestData } from "../../../../utils/tests/test-data";
+
+describe("crypto-service", () => {
+    describe("getPublicEncryptionKey", () => {
+        const mockKMSClient = mockClient(KMSClient);
+
+        afterEach(() => {
+            mockKMSClient.reset();
+            clearCaches();
+        });
+
+        it("throws error with 500 if decryption key env variable not set", async () => {
+            await expect(getPublicEncryptionKey()).rejects.toThrow(
+                new HeadlessCoreStubError("Decryption key ID not present", 500),
+            );
+        });
+
+        it("throws error with 500 if kms key not retrieved", async () => {
+            process.env.DECRYPTION_KEY_ID = "abc123";
+            await expect(getPublicEncryptionKey()).rejects.toThrow(
+                new HeadlessCoreStubError("Unable to retrieve public encryption key", 500),
+            );
+        });
+
+        it("retrieves public encryption key", async () => {
+            const { publicKey } = generateKeyPairSync("rsa", {
+                modulusLength: 2048,
+                publicKeyEncoding: {
+                    type: "spki",
+                    format: "der",
+                },
+                privateKeyEncoding: {
+                    type: "pkcs8",
+                    format: "der",
+                },
+            });
+            const keyBuffer = Buffer.from(publicKey);
+
+            process.env.DECRYPTION_KEY_ID = "abc123";
+
+            const mockKMSClient = mockClient(KMSClient);
+            mockKMSClient.on(GetPublicKeyCommand, { KeyId: "abc123" }).resolvesOnce({ PublicKey: keyBuffer });
+
+            const result = await getPublicEncryptionKey();
+            expect(result.type).toEqual("public");
+        });
+    });
+
+    describe("encryptSignedJwt", () => {
+        it("creates encrypted signed jwt", async () => {
+            const { publicKey } = generateKeyPairSync("rsa", {
+                modulusLength: 2048,
+                publicKeyEncoding: {
+                    type: "spki",
+                    format: "der",
+                },
+                privateKeyEncoding: {
+                    type: "pkcs8",
+                    format: "der",
+                },
+            });
+            const keyBuffer = Buffer.from(publicKey);
+
+            process.env.DECRYPTION_KEY_ID = "abc123";
+
+            const mockKMSClient = mockClient(KMSClient);
+            mockKMSClient.on(GetPublicKeyCommand, { KeyId: "abc123" }).resolvesOnce({ PublicKey: keyBuffer });
+
+            const publicEncryptionKey = await getPublicEncryptionKey();
+
+            const result = await encryptSignedJwt(TestData.jwt, publicEncryptionKey);
+            expect(result).toMatch(
+                /^eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/g,
+            );
+        });
+    });
+});

--- a/test-resources/headless-core-stub/lambdas/start/tests/start-handler.test.ts
+++ b/test-resources/headless-core-stub/lambdas/start/tests/start-handler.test.ts
@@ -1,9 +1,142 @@
+import { clearCaches } from "@aws-lambda-powertools/parameters";
+import { GetPublicKeyCommand, KMSClient } from "@aws-sdk/client-kms";
+import { APIGatewayProxyEvent } from "aws-lambda/trigger/api-gateway-proxy";
+import { mockClient } from "aws-sdk-client-mock";
+import { generateKeyPairSync } from "crypto";
 import { StartLambdaHandler } from "../src/start-handler";
+import { TestData } from "../../../utils/tests/test-data";
+import { Context } from "aws-lambda";
+import { ClientConfiguration } from "../../../utils/src/services/client-configuration";
+
+jest.mock("../../../utils/src/services/client-configuration");
 
 describe("start-handler", () => {
-    it("Returns 200", async () => {
+    process.env.DECRYPTION_KEY_ID = "abc123";
+    const mockKMSClient = mockClient(KMSClient);
+
+    let getParametersSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        getParametersSpy = jest.spyOn(ClientConfiguration, "getConfig").mockResolvedValueOnce({
+            redirectUri: "https://localhost/callback",
+            audience: "https://localhost",
+            issuer: "https://localhost",
+            privateSigningKey: JSON.stringify(TestData.privateSigningKey),
+        });
+
+        const { publicKey } = generateKeyPairSync("rsa", {
+            modulusLength: 2048,
+            publicKeyEncoding: {
+                type: "spki",
+                format: "der",
+            },
+            privateKeyEncoding: {
+                type: "pkcs8",
+                format: "der",
+            },
+        });
+
+        mockKMSClient.on(GetPublicKeyCommand, { KeyId: "abc123" }).resolvesOnce({ PublicKey: Buffer.from(publicKey) });
+    });
+
+    afterEach(() => {
+        mockKMSClient.reset();
+        clearCaches();
+    });
+
+    it("returns 200 when body is empty", async () => {
+        expect(true);
         const startLambdaHandler = new StartLambdaHandler();
-        const result = await startLambdaHandler.handler();
-        expect(result).toEqual({ status: "200", body: "Hello start" });
+        const event = {
+            body: JSON.stringify({}),
+        } as unknown as APIGatewayProxyEvent;
+
+        const result = await startLambdaHandler.handler(event, {} as Context);
+        expect(result.statusCode).toEqual(200);
+        const body = JSON.parse(result.body);
+        expect(body.client_id).toEqual("ipv-core-stub-aws-headless");
+        expect(getParametersSpy).toHaveBeenCalledWith(body.client_id);
+        expect(body.request).toMatch(
+            /^eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/g,
+        );
+    });
+
+    it("returns 200 when body is null", async () => {
+        expect(true);
+        const startLambdaHandler = new StartLambdaHandler();
+        const event = {
+            body: null,
+        } as unknown as APIGatewayProxyEvent;
+
+        const result = await startLambdaHandler.handler(event, {} as Context);
+        expect(result.statusCode).toEqual(200);
+        const body = JSON.parse(result.body);
+        expect(body.client_id).toEqual("ipv-core-stub-aws-headless");
+        expect(body.request).toMatch(
+            /^eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/g,
+        );
+    });
+
+    it("returns 200 when body is fully populated with overrides", async () => {
+        expect(true);
+        const startLambdaHandler = new StartLambdaHandler();
+        const event = {
+            body: JSON.stringify(TestData.jwtClaimsSet),
+        } as unknown as APIGatewayProxyEvent;
+
+        const result = await startLambdaHandler.handler(event, {} as Context);
+        expect(result.statusCode).toEqual(200);
+        const body = JSON.parse(result.body);
+        expect(body.client_id).toEqual("ipv-core-stub-aws-headless");
+        expect(body.request).toMatch(
+            /^eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/g,
+        );
+    });
+
+    it("returns 200 when body has an overridden client_id", async () => {
+        expect(true);
+        const startLambdaHandler = new StartLambdaHandler();
+        const event = {
+            body: JSON.stringify({ client_id: "mock-client-id" }),
+        } as unknown as APIGatewayProxyEvent;
+
+        const result = await startLambdaHandler.handler(event, {} as Context);
+        expect(result.statusCode).toEqual(200);
+        const body = JSON.parse(result.body);
+        expect(body.client_id).toEqual("mock-client-id");
+        expect(getParametersSpy).toHaveBeenCalledWith(body.client_id);
+        expect(body.request).toMatch(
+            /^eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/g,
+        );
+    });
+
+    it("returns 400 when claims set fails validation - aud is not a valid uri", async () => {
+        expect(true);
+        const startLambdaHandler = new StartLambdaHandler();
+        const event = {
+            body: JSON.stringify({
+                aud: "invalid",
+            }),
+        } as unknown as APIGatewayProxyEvent;
+
+        const result = await startLambdaHandler.handler(event, {} as Context);
+        expect(result).toEqual({
+            body: '{"message":"Claims set failed validation: /aud - must match format \\"uri\\""}',
+            statusCode: 400,
+        });
+    });
+
+    it("returns 400 when body is not valid json", async () => {
+        expect(true);
+        const startLambdaHandler = new StartLambdaHandler();
+        const event = {
+            body: "{",
+        } as unknown as APIGatewayProxyEvent;
+
+        const result = await startLambdaHandler.handler(event, {} as Context);
+        expect(result).toEqual({
+            body: '{"message":"Body is not valid JSON"}',
+            statusCode: 400,
+        });
     });
 });

--- a/test-resources/headless-core-stub/utils/tests/crypto/signer.test.ts
+++ b/test-resources/headless-core-stub/utils/tests/crypto/signer.test.ts
@@ -1,0 +1,11 @@
+import { signJwt } from "../../../utils/src/crypto/signer";
+import { TestData } from "../test-data";
+
+describe("signJwt", () => {
+    it("retrieves private signing key", async () => {
+        const result = await signJwt(TestData.jwtPayload, TestData.privateSigningKey);
+        expect(result).toMatch(/eyJ[A-Za-z0-9-_]+\.eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_.+/]*/g);
+        const expJwtWithoutSigRegex = new RegExp(`^${TestData.jwtWithoutSig}?`);
+        expect(result).toMatch(expJwtWithoutSigRegex);
+    });
+});

--- a/test-resources/headless-core-stub/utils/tests/test-data.ts
+++ b/test-resources/headless-core-stub/utils/tests/test-data.ts
@@ -1,0 +1,66 @@
+import { JWTPayload } from "jose";
+import { JWTClaimsSet } from "../../lambdas/start/src/types/jwt-claims-set";
+
+export class TestData {
+    static privateSigningKey = {
+        kty: "EC",
+        d: "_0A_bq8i4sKtrlRMJrYWO5OoZnT1PeJjTAFN1pj-nIg",
+        use: "sig",
+        crv: "P-256",
+        kid: "qs1Pk2hlU7yi1ZS8KahLWiPbkS4sg2rN2_SZNCwjR0c",
+        x: "bmq8WpXGO6zpasLAd_ESqKlFXp99kgfydj0apnQ3Wyw",
+        y: "xaS8yXipEFCk_KJxp3V5wz2cFeWVnwTp4zGL9Qc4CAY",
+        alg: "ES256",
+    };
+
+    static jwt =
+        "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJodHRwczovL2xvY2FsaG9zdC5jb20iLCJjbGllbnRfaWQiOiJpcHYtY29yZS1zdHViLWF3cy1oZWFkbGVzcyIsImV4cCI6MTc0MjM4NTI0NCwiZ292dWtfc2lnbmluX2pvdXJuZXlfaWQiOiJkNmUwMGE5Yi1kNjZhLTQ1NzItYjMzMS0zMThlZGYzMDdlY2EiLCJpYXQiOjE3NDIzODQ5NDUsImlzcyI6Imh0dHBzOi8vbG9jYWxob3N0LmNvbSIsIm5iZiI6MTc0MjM4NDk0NSwibm9uY2UiOiIiLCJyZWRpcmVjdF91cmkiOiJodHRwczovL2xvY2FsaG9zdC5jb20vY2FsbGJhY2siLCJyZXNwb25zZV90eXBlIjoiY29kZSIsInNjb3BlIjoiIiwic2hhcmVkX2NsYWltcyI6eyJhZGRyZXNzIjpbeyJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwiYnVpbGRpbmdOdW1iZXIiOiI4IiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJzdHJlZXROYW1lIjoiSEFETEVZIFJPQUQiLCJ2YWxpZEZyb20iOiIyMDIxLTAxLTAxIn1dLCJiaXJ0aERhdGUiOlt7InZhbHVlIjoiMTk2NS0wNy0wOCJ9XSwibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ0eXBlIjoiR2l2ZW5OYW1lIiwidmFsdWUiOiJLRU5ORVRIIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiREVDRVJRVUVJUkEifV19XX0sInN0YXRlIjoiYjcyYjBhYzYtNDAzOC00NGUxLTkwNGMtZjFlMDc4MzJmMjY2Iiwic3ViIjoidXJuOmZkYzpnb3YudWs6YTlmYjhlMzgtMDQ1OC00ZGMwLThiZWMtMjY2MjcwOWNiMjQwIn0.xIOMcA0sCSe3N2NVpasT1uTkL936trpvvply5wDC6kKwtNkLYIh9LjuheNBABCMumdbOVVjaaxDAvk3Ej87LyA";
+
+    static jwtWithoutSig =
+        "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJodHRwczovL2xvY2FsaG9zdC5jb20iLCJjbGllbnRfaWQiOiJpcHYtY29yZS1zdHViLWF3cy1oZWFkbGVzcyIsImV4cCI6MTc0MjM4NTI0NCwiZ292dWtfc2lnbmluX2pvdXJuZXlfaWQiOiJkNmUwMGE5Yi1kNjZhLTQ1NzItYjMzMS0zMThlZGYzMDdlY2EiLCJpYXQiOjE3NDIzODQ5NDUsImlzcyI6Imh0dHBzOi8vbG9jYWxob3N0LmNvbSIsIm5iZiI6MTc0MjM4NDk0NSwicmVkaXJlY3RfdXJpIjoiaHR0cHM6Ly9sb2NhbGhvc3QuY29tL2NhbGxiYWNrIiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJzaGFyZWRfY2xhaW1zIjp7ImFkZHJlc3MiOlt7ImFkZHJlc3NMb2NhbGl0eSI6IkJBVEgiLCJidWlsZGluZ051bWJlciI6IjgiLCJwb3N0YWxDb2RlIjoiQkEyIDVBQSIsInN0cmVldE5hbWUiOiJIQURMRVkgUk9BRCIsInZhbGlkRnJvbSI6IjIwMjEtMDEtMDEifV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTY1LTA3LTA4In1dLCJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6IktFTk5FVEgifSx7InR5cGUiOiJGYW1pbHlOYW1lIiwidmFsdWUiOiJERUNFUlFVRUlSQSJ9XX1dfSwic3RhdGUiOiJiNzJiMGFjNi00MDM4LTQ0ZTEtOTA0Yy1mMWUwNzgzMmYyNjYiLCJzdWIiOiJ1cm46ZmRjOmdvdi51azphOWZiOGUzOC0wNDU4LTRkYzAtOGJlYy0yNjYyNzA5Y2IyNDAifQ.";
+    static jwtClaimsSet: JWTClaimsSet = {
+        aud: "https://localhost.com",
+        client_id: "ipv-core-stub-aws-headless",
+        exp: 1742385244,
+        govuk_signin_journey_id: "d6e00a9b-d66a-4572-b331-318edf307eca",
+        iat: 1742384945,
+        iss: "https://localhost.com",
+        nbf: 1742384945,
+        redirect_uri: "https://localhost.com/callback",
+        response_type: "code",
+        shared_claims: {
+            address: [
+                {
+                    addressLocality: "BATH",
+                    buildingNumber: "8",
+                    postalCode: "BA2 5AA",
+                    streetName: "HADLEY ROAD",
+                    validFrom: "2021-01-01",
+                },
+            ],
+            birthDate: [
+                {
+                    value: "1965-07-08",
+                },
+            ],
+            name: [
+                {
+                    nameParts: [
+                        {
+                            type: "GivenName",
+                            value: "KENNETH",
+                        },
+                        {
+                            type: "FamilyName",
+                            value: "DECERQUEIRA",
+                        },
+                    ],
+                },
+            ],
+        },
+        state: "b72b0ac6-4038-44e1-904c-f1e07832f266",
+        sub: "urn:fdc:gov.uk:a9fb8e38-0458-4dc0-8bec-2662709cb240",
+    };
+
+    static jwtPayload: JWTPayload = TestData.jwtClaimsSet as JWTPayload;
+}

--- a/test-resources/headless-core-stub/utils/tsconfig.json
+++ b/test-resources/headless-core-stub/utils/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "experimentalDecorators": true,
+        "target": "es2022",
+        "strict": true,
+        "preserveConstEnums": true,
+        "sourceMap": true,
+        "module": "es2022",
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "types": ["jest", "node", "aws-lambda"],
+        "outDir": "./build/",
+        "noImplicitAny": true
+    },
+    "exclude": ["node_modules", "build", "coverage"],
+    "include": ["src", "tests"]
+}

--- a/test-resources/infrastructure/public-api.yaml
+++ b/test-resources/infrastructure/public-api.yaml
@@ -106,7 +106,39 @@ paths:
             statusCode: 200
             responseTemplates:
               application/json: |
-                $input.json('$.Items')
+                $input.json('$.Items')           
+  /start:
+    post:
+      security:
+        - sigv4Reference: [ ]
+      description: Headless core stub start. Used for testing purposes only.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JWTClaimsSetOverrides"
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StartResponse"
+        400:
+          description: Bad request
+        500:
+          description: Internal server error
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${StartFunction.Arn}:live/invocations
+        responses:
+          default:
+            statusCode: "200"
+        passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws_proxy"
 
 x-amazon-apigateway-request-validators:
   Validate both:
@@ -133,3 +165,76 @@ components:
       name: Authorization
       in: header
       x-amazon-apigateway-authtype: awsSigv4
+  schemas:
+    JWTClaimsSetOverrides:
+      type: "object"
+      properties:
+        iss:
+          type: "string"
+          format: "uri"
+          description: "An identifier of the issuer of the JWT"
+          example: "https://localhost/callback"
+        sub:
+          type: "string"
+          format: "uri"
+          description: "The user's subject identifier"
+          example: "urn:fdc:gov.uk:a9fb8e38-0458-4dc0-8bec-2662709cb240"
+        aud:
+          type: "string"
+          format: "uri"
+          description: "An identifier of the recipient of the JWT, ie the credential issuer/collector server"
+          example: "https://review-a.dev.account.gov.uk"
+        iat:
+          type: "number"
+          description: "Issued at (seconds)"
+          example: "1742384945"
+        exp:
+          type: "number"
+          description: "Expiration (seconds)"
+          example: "1742384945"
+        nbf:
+          type: "number"
+          description: "Not before (seconds)"
+          example: "1742384945"
+        response_type:
+          type: "string"
+          example: "code"
+        client_id:
+          type: "string"
+          description: "The OAuth client identifier"
+          example: "ipv-core-stub-aws-headless"
+        redirect_uri:
+          type: "string"
+          format: "uri"
+          description: "The OAuth client redirect uri, where the user will be redirected in the authorization response"
+          example: "https://localhost/callback"
+        state:
+          type: "string"
+          description: "A random state value, to be returned in the authorization response"
+          example: "b72b0ac6-4038-44e1-904c-f1e07832f266"
+        govuk_signin_journey_id:
+          type: "string"
+          description: "a non-empty string value used to correlate sessions across IPV and credential issuers"
+          example: "d6e00a9b-d66a-4572-b331-318edf307eca"
+        shared_claims:
+          type: "object"
+          description: "User information for credential issuing"
+        evidence_requested:
+          type: "object"
+          description: "Configure the checks being requested to a Credential Issuer"
+        context:
+          type: "string"
+          description: "Configure the information collected from a user by Credential Collector"
+          example: "international_user"
+    StartResponse:
+      required:
+        - "client_id"
+        - "request"
+      type: "object"
+      properties:
+        client_id:
+          type: "string"
+          minLength: 1
+          example: "ipv-core-stub-aws-headless"
+        request:
+          type: "string"

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -96,6 +96,52 @@ Resources:
       VpcId:
         Fn::ImportValue: !Sub "${VpcStackName}-VpcId"
 
+  StartFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Sourcemap: true
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-StartFunction"
+      Handler: headless-core-stub/lambdas/start/src/start-handler.lambdaHandler
+      CodeSigningConfigArn:
+        !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+      LoggingConfig:
+        LogGroup: !Sub /aws/lambda/${AWS::StackName}/StartFunction
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: HeadlessCoreStubStartFunction
+          DECRYPTION_KEY_ID: !ImportValue core-infrastructure-CriDecryptionKey1Id
+          AWS_STACK_NAME: !Ref CommonStackName
+      Policies:
+        - Statement:
+            Effect: Allow
+            Action: 'kms:GetPublicKey'
+            Resource: !Sub 'arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*'
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParametersByPath
+                - ssm:GetParameters
+                - ssm:GetParameter
+              Resource:
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/clients/*/jwtAuthentication/*"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/test-resources/ipv-core-stub-aws-headless/privateSigningKey"
+  
+  StartFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}/StartFunction"
+      RetentionInDays: 30
+
+  StartFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref StartFunction.Alias
+      Principal: apigateway.amazonaws.com
+
   CallbackFunction:
     Type: AWS::Serverless::Function
     Metadata:
@@ -103,6 +149,7 @@ Resources:
       BuildProperties:
         Sourcemap: true
     Properties:
+      FunctionName: !Sub "${AWS::StackName}-CallbackFunction"
       Handler: headless-core-stub/lambdas/callback/src/callback-handler.lambdaHandler
       CodeSigningConfigArn:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]

--- a/test-resources/package.json
+++ b/test-resources/package.json
@@ -7,12 +7,12 @@
     "scripts": {
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
-        "unit": "export POWERTOOLS_DEV=true && jest --silent",
-        "unit:logs": "jest",
+        "sam:build": "npm run sam:validate && sam build --template infrastructure/template.yaml --cached --parallel",
+        "sam:validate": "cd infrastructure && sam validate && sam validate --lint",
         "test": "npm run unit --",
         "test:coverage": "npm run unit -- --coverage",
-        "sam:validate": "cd infrastructure && sam validate && sam validate --lint",
-        "sam:build": "npm run sam:validate && sam build --template infrastructure/template.yaml --cached --parallel"
+        "unit": "export POWERTOOLS_DEV=true && jest --silent",
+        "unit:logs": "jest"
     },
     "dependencies": {
         "@aws-lambda-powertools/commons": "2.16.0",
@@ -22,9 +22,13 @@
         "@aws-sdk/client-ssm": "3.772.0",
         "@govuk-one-login/data-vocab": "1.9.3",
         "@govuk-one-login/data-vocab-schemas": "1.9.3",
+        "@middy/core": "4.2.8",
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
+        "aws-sdk-client-mock": "4.1.0",
         "ecdsa-sig-formatter": "1.0.11",
-        "jose": "5.10.0",
-        "esbuild": "0.25.1"
+        "esbuild": "0.25.1",
+        "jose": "5.10.0"
     },
     "devDependencies": {
         "@types/aws-lambda": "^8.10.145",


### PR DESCRIPTION
## Proposed changes

### What changed

- Added `/start` endpoint to the test-resources stack. 

### Why did it change

We want a headless, typescript core stub that has a /start endpoint that returns a JWT that can be used to start a session in any CRI frontend.

### Issue tracking

- [OJ-2331](https://govukverify.atlassian.net/browse/OJ-2331)


[OJ-2331]: https://govukverify.atlassian.net/browse/OJ-2331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ