### PR TITLE
OJ-3128: conditionally add protected subnet

### DIFF
--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -48,6 +48,13 @@ Mappings:
         dev: review-k.dev.account.gov.uk
         build: review-k.build.account.gov.uk
         staging: review-k.staging.account.gov.uk
+  CriVpcMapping:
+    di-ipv-cri-check-hmrc-api:
+      pipeline: "di-devplatform-deploy"
+    di-ipv-cri-address-api:
+      pipeline: "di-ipv-cri-pipeline-deployment"
+    di-ipv-cri-kbv-api:
+      pipeline: "di-ipv-cri-pipeline-deployment"
 
 Conditions:
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
@@ -55,6 +62,7 @@ Conditions:
   DequeueEvents: !Not [!Equals [!Ref Environment, localdev]]
   # Don't create domain resources for the common dev account as there are none
   CreateDomainResources: !Not [!Equals [!Sub "${AWS::AccountId}", "486210938254"]]
+  IsDevPlatformDeploy: !Equals [ !FindInMap [ CriVpcMapping, !Ref CriIdentifier, "pipeline" ], "di-devplatform-deploy" ]
 
 Globals:
   Function:
@@ -67,9 +75,10 @@ Globals:
     VpcConfig:
       SecurityGroupIds:
         - !ImportValue cri-vpc-AWSServicesEndpointSecurityGroupId
-      SubnetIds:
-        - !ImportValue cri-vpc-ProtectedSubnetIdA
-        - !ImportValue cri-vpc-ProtectedSubnetIdB
+      SubnetIds: !If
+        - IsDevPlatformDeploy
+        - [ !ImportValue cri-vpc-ProtectedSubnetIdA, !ImportValue cri-vpc-ProtectedSubnetIdB ]
+        - [ !ImportValue cri-vpc-PrivateSubnetIdA, !ImportValue cri-vpc-PrivateSubnetIdB ]
     Tracing: Active
     MemorySize: 1024
     Environment:

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -56,13 +56,19 @@ Mappings:
     di-ipv-cri-kbv-api:
       pipeline: "di-ipv-cri-pipeline-deployment"
 
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - W8003
+
 Conditions:
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]
   DequeueEvents: !Not [!Equals [!Ref Environment, localdev]]
   # Don't create domain resources for the common dev account as there are none
   CreateDomainResources: !Not [!Equals [!Sub "${AWS::AccountId}", "486210938254"]]
-  IsDevPlatformDeploy: !Equals [ !FindInMap [ CriVpcMapping, !Ref CriIdentifier, "pipeline" ], "di-devplatform-deploy" ]
+  IsDevPlatformDeploy: !Equals [ !FindInMap [ CriVpcMapping, !Ref CriIdentifier, "pipeline"  ], "di-devplatform-deploy" ]
 
 Globals:
   Function:


### PR DESCRIPTION
### What changed

The pipeline for Experian KBV and Address CRI broke because there is no protected subnet,  Protected subnet is required
for /callback to be able to make calls successfully to public CRI endpoints like /token and /credential/issue

### Why did it change

Headless core stub would need to be able to call public endpoint irrespective of what the CRI is

### Issue tracking

- [OJ-3128](https://govukverify.atlassian.net/browse/OJ-3128)


[OJ-3128]: https://govukverify.atlassian.net/browse/OJ-3128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ