### PR TITLE
OJ-3122: Update clean up stacks to include all preview stacks

### DIFF
--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -29,7 +29,7 @@ jobs:
         uses: govuk-one-login/github-actions/sam/get-stale-stacks@ca188729ecb0c92e5fe5ae7c024f9894815da3a1
         with:
           threshold-days: 14
-          stack-name-filter: preview-common-lambdas
+          stack-name-filter: preview
           stack-tag-filters: |
             cri:deployment-source=github-actions
             cri:stack-type=preview


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update clean up stacks to include all preview stacks

### Why did it change

So that test resources stacks are also cleaned up 

### Screenshots
<img width="553" alt="Screenshot 2025-03-31 at 11 26 00 am" src="https://github.com/user-attachments/assets/3dbcec54-bd84-4483-addc-3e79a9db6918" />


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3122](https://govukverify.atlassian.net/browse/OJ-3122)



[OJ-3122]: https://govukverify.atlassian.net/browse/OJ-3122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ