### PR TITLE
LIME-1592 Added support for key rotation 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		cri_common_lib           : "4.0.0",
+		webcompere_version       : "2.1.7",
 	]
 }
 
@@ -97,6 +98,7 @@ subprojects {
 		cucumberRuntime
 		cri_common_lib
 		pact_tests
+		webcompere
 	}
 
 	configurations.all {
@@ -144,7 +146,9 @@ subprojects {
 				"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit}",
 				"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito}",
 				"org.mockito:mockito-inline:${dependencyVersions.mockito}",
-				"org.hamcrest:hamcrest:2.2"
+				"org.hamcrest:hamcrest:2.2",
+				"uk.org.webcompere:system-stubs-core:${dependencyVersions.webcompere_version}",
+				"uk.org.webcompere:system-stubs-jupiter:${dependencyVersions.webcompere_version}"
 
 		pact_tests "au.com.dius.pact.provider:junit5:4.5.8",
 				"au.com.dius.pact:provider:4.5.8",

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,6 +29,6 @@ sam deploy --stack-name "$stack_name" \
   cri:deployment-source=manual \
   cri:stack-type=localdev \
   --parameter-overrides \
-  Environment=localdev \
+  Environment=dev \
   ${audit_event_name_prefix:+AuditEventNamePrefix=$audit_event_name_prefix} \
   ${cri_identifier:+CriIdentifier=$cri_identifier}

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -3,6 +3,12 @@ Transform:
   - AWS::Serverless-2016-10-31
   - AWS::LanguageExtensions
 Description: "Digital Identity IPV CRI common API"
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+        - W8003
+        - E3031
 
 Parameters:
   CodeSigningConfigArn:
@@ -157,6 +163,7 @@ Globals:
               ]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
 
+
 Mappings:
 
   EnvironmentConfiguration:
@@ -186,6 +193,51 @@ Mappings:
       staging: 7200 # 2 hours
       integration: 7200 # 2 hours
       production: 7200 # 2 hours
+
+# Use key rotation aliases in session decryption
+  KeyRotationMapping:
+    di-ipv-cri-address-api:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+    di-ipv-cri-fraud-api:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+    di-ipv-cri-kbv-api:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+    di-ipv-cri-dl-api:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+    di-ipv-cri-passport-api:
+      dev: "true"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+    di-ipv-cri-kbv-hmrc-api:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+    di-ipv-cri-check-hmrc-api:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
 
   # TS functions Only 0 = off
   TSProvisionedConcurrencyMapping:
@@ -604,6 +656,7 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-session"
           SQS_AUDIT_EVENT_QUEUE_URL:
             Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
+          ENV_VAR_FEATURE_FLAG_KEY_ROTATION: !FindInMap [ KeyRotationMapping, !Ref CriIdentifier, !Ref Environment]
       AutoPublishAlias: live
       AutoPublishAliasAllProperties: true
       SnapStart:

--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/KMSRSADecrypter.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/KMSRSADecrypter.java
@@ -9,6 +9,8 @@ import com.nimbusds.jose.crypto.impl.AlgorithmSupportMessage;
 import com.nimbusds.jose.crypto.impl.ContentCryptoProvider;
 import com.nimbusds.jose.jca.JWEJCAContext;
 import com.nimbusds.jose.util.Base64URL;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
@@ -21,11 +23,21 @@ import javax.crypto.spec.SecretKeySpec;
 import java.util.Objects;
 import java.util.Set;
 
+import static software.amazon.awssdk.services.kms.model.EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256;
+
 class KMSRSADecrypter implements JWEDecrypter {
     private static final Set<JWEAlgorithm> SUPPORTED_ALGORITHMS = Set.of(JWEAlgorithm.RSA_OAEP_256);
     private static final Set<EncryptionMethod> SUPPORTED_ENCRYPTION_METHODS =
             Set.of(EncryptionMethod.A256GCM);
-
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static final String SESSION_DECRYPTION_KEY_PRIMARY_ALIAS =
+            "session_decryption_key_active_alias";
+    private static final String SESSION_DECRYPTION_KEY_SECONDARY_ALIAS =
+            "session_decryption_key_inactive_alias";
+    private static final String SESSION_DECRYPTION_KEY_PREVIOUS_ALIAS =
+            "session_decryption_key_previous_alias";
+    private final boolean keyRotationEnabled =
+            Boolean.parseBoolean(System.getenv("ENV_VAR_FEATURE_FLAG_KEY_ROTATION"));
     private final JWEJCAContext jcaContext;
     private final KmsClient kmsClient;
     private final String keyId;
@@ -64,18 +76,59 @@ class KMSRSADecrypter implements JWEDecrypter {
             throw new JOSEException(
                     AlgorithmSupportMessage.unsupportedJWEAlgorithm(alg, supportedJWEAlgorithms()));
         }
+        DecryptResponse decryptResponse;
+        if (keyRotationEnabled) {
+            LOGGER.info("Key rotation enabled. Attempting to decrypt with key aliases.");
+            // During a key rotation we might receive JWTs encrypted with either the old or new key.
+            decryptResponse = decryptWithKeyAliases(encryptedKey);
 
-        DecryptRequest decryptRequest =
-                DecryptRequest.builder()
-                        .encryptionAlgorithm(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256)
-                        .ciphertextBlob(SdkBytes.fromByteArray(encryptedKey.decode()))
-                        .keyId(this.keyId)
-                        .build();
-        DecryptResponse decryptResponse = this.kmsClient.decrypt(decryptRequest);
+            if (decryptResponse == null) {
+                String message = "Failed to decrypt with all available key aliases.";
+                LOGGER.error(message);
+                throw new JOSEException(message);
+            }
+        } else {
+            DecryptRequest decryptRequest =
+                    DecryptRequest.builder()
+                            .encryptionAlgorithm(EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256)
+                            .ciphertextBlob(SdkBytes.fromByteArray(encryptedKey.decode()))
+                            .keyId(this.keyId)
+                            .build();
+            decryptResponse = this.kmsClient.decrypt(decryptRequest);
+        }
+
         SecretKey cek = new SecretKeySpec(decryptResponse.plaintext().asByteArray(), "AES");
-
         return ContentCryptoProvider.decrypt(
                 header, null, encryptedKey, iv, cipherText, authTag, cek, getJCAContext());
+    }
+
+    private DecryptResponse decryptWithKeyAliases(Base64URL encryptedKey) {
+        String[] keyAliases = {
+            SESSION_DECRYPTION_KEY_PRIMARY_ALIAS,
+            SESSION_DECRYPTION_KEY_SECONDARY_ALIAS,
+            SESSION_DECRYPTION_KEY_PREVIOUS_ALIAS
+        };
+
+        DecryptResponse decryptResponse = null;
+        for (String alias : keyAliases) {
+            try {
+                decryptResponse = kmsClient.decrypt(buildDecryptRequest(alias, encryptedKey));
+                LOGGER.info("Decryption successful with key alias: {}", alias);
+                break;
+            } catch (Exception e) {
+                LOGGER.warn(
+                        "Failed to decrypt with key alias: {}. Error: {}", alias, e.getMessage());
+            }
+        }
+        return decryptResponse;
+    }
+
+    private DecryptRequest buildDecryptRequest(String keyAlias, Base64URL encryptedKey) {
+        return DecryptRequest.builder()
+                .ciphertextBlob(SdkBytes.fromByteArray(encryptedKey.decode()))
+                .encryptionAlgorithm(RSAES_OAEP_SHA_256)
+                .keyId("alias/" + keyAlias)
+                .build();
     }
 
     @Override

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/KMSRSADecrypterTest.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/KMSRSADecrypterTest.java
@@ -18,6 +18,9 @@ import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
 import software.amazon.awssdk.services.kms.model.DecryptResponse;
 import software.amazon.awssdk.services.kms.model.EncryptionAlgorithmSpec;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
@@ -27,22 +30,34 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(SystemStubsExtension.class)
 @ExtendWith(MockitoExtension.class)
 class KMSRSADecrypterTest {
+
+    @SystemStub
+    private static final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
     private static final String TEST_KEY_ID = "test-key";
     @Mock private KmsClient mockKmsClient;
-    private KMSRSADecrypter kmsRsaDecrypter;
+    private static final String SESSION_DECRYPTION_KEY_PRIMARY_ALIAS =
+            "session_decryption_key_active_alias";
+    private static final String SESSION_DECRYPTION_KEY_SECONDARY_ALIAS =
+            "session_decryption_key_inactive_alias";
+    private static final String SESSION_DECRYPTION_KEY_PREVIOUS_ALIAS =
+            "session_decryption_key_previous_alias";
 
     @BeforeEach
     void setup() {
-        this.kmsRsaDecrypter = new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient);
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "false");
     }
 
     @Test
     void shouldDecrypt() throws ParseException, JOSEException {
+        KMSRSADecrypter kmsRsaDecrypter = new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient);
         JWEHeader header = createHeader();
         Base64URL encryptedKey =
                 Base64URL.from(
@@ -60,15 +75,12 @@ class KMSRSADecrypterTest {
                                                 .decode(
                                                         "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
                         .build();
-
         when(mockKmsClient.decrypt(any(DecryptRequest.class))).thenReturn(decryptResponse);
-
         byte[] result =
-                this.kmsRsaDecrypter.decrypt(
+                kmsRsaDecrypter.decrypt(
                         header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
         SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
         JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
-
         ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
                 ArgumentCaptor.forClass(DecryptRequest.class);
         verify(mockKmsClient).decrypt(decryptRequestArgumentCaptor.capture());
@@ -85,13 +97,178 @@ class KMSRSADecrypterTest {
     }
 
     @Test
+    void shouldDecryptWithPrimaryAlias() throws ParseException, JOSEException {
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+        KMSRSADecrypter kmsRsaDecrypter = new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient);
+        JWEHeader header = createHeader();
+        Base64URL encryptedKey =
+                Base64URL.from(
+                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+        Base64URL cipherText =
+                Base64URL.from(
+                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+        DecryptResponse decryptResponse =
+                DecryptResponse.builder()
+                        .keyId(TEST_KEY_ID)
+                        .plaintext(
+                                SdkBytes.fromByteArray(
+                                        Base64.getDecoder()
+                                                .decode(
+                                                        "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
+                        .build();
+        when(mockKmsClient.decrypt(any(DecryptRequest.class))).thenReturn(decryptResponse);
+        byte[] result =
+                kmsRsaDecrypter.decrypt(
+                        header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
+        SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
+        JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+        ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
+                ArgumentCaptor.forClass(DecryptRequest.class);
+        verify(mockKmsClient).decrypt(decryptRequestArgumentCaptor.capture());
+        DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
+        assertEquals(
+                EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
+                actualDecryptRequest.encryptionAlgorithmAsString());
+        assertEquals("alias/" + SESSION_DECRYPTION_KEY_PRIMARY_ALIAS, actualDecryptRequest.keyId());
+        assertArrayEquals(
+                encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
+        assertEquals(11, claims.getClaims().size());
+        assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
+        assertEquals("ipv-core-stub", claims.getIssuer());
+    }
+
+    @Test
+    void shouldDecryptWithSecondaryAlias() throws ParseException, JOSEException {
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+        KMSRSADecrypter kmsRsaDecrypter = new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient);
+        JWEHeader header = createHeader();
+        Base64URL encryptedKey =
+                Base64URL.from(
+                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+        Base64URL cipherText =
+                Base64URL.from(
+                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+        DecryptResponse decryptResponse =
+                DecryptResponse.builder()
+                        .plaintext(
+                                SdkBytes.fromByteArray(
+                                        Base64.getDecoder()
+                                                .decode(
+                                                        "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
+                        .build();
+        when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                .thenThrow(new RuntimeException("primary key failed to decrypt"))
+                .thenReturn(decryptResponse);
+        byte[] result =
+                kmsRsaDecrypter.decrypt(
+                        header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
+        SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
+        JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+        ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
+                ArgumentCaptor.forClass(DecryptRequest.class);
+        verify(mockKmsClient, times(2)).decrypt(decryptRequestArgumentCaptor.capture());
+        DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
+        assertEquals(
+                EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
+                actualDecryptRequest.encryptionAlgorithmAsString());
+        assertEquals(
+                "alias/" + SESSION_DECRYPTION_KEY_SECONDARY_ALIAS, actualDecryptRequest.keyId());
+        assertArrayEquals(
+                encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
+        assertEquals(11, claims.getClaims().size());
+        assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
+        assertEquals("ipv-core-stub", claims.getIssuer());
+    }
+
+    @Test
+    void shouldDecryptWithPreviousAlias() throws ParseException, JOSEException {
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+        KMSRSADecrypter kmsRsaDecrypter = new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient);
+        JWEHeader header = createHeader();
+        Base64URL encryptedKey =
+                Base64URL.from(
+                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+        Base64URL cipherText =
+                Base64URL.from(
+                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+        DecryptResponse decryptResponse =
+                DecryptResponse.builder()
+                        .plaintext(
+                                SdkBytes.fromByteArray(
+                                        Base64.getDecoder()
+                                                .decode(
+                                                        "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
+                        .build();
+        when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                .thenThrow(new RuntimeException("primary key failed to decrypt"))
+                .thenThrow(new RuntimeException("secondary key failed to decrypt"))
+                .thenReturn(decryptResponse);
+        byte[] result =
+                kmsRsaDecrypter.decrypt(
+                        header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
+        SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
+        JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+        ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
+                ArgumentCaptor.forClass(DecryptRequest.class);
+        verify(mockKmsClient, times(3)).decrypt(decryptRequestArgumentCaptor.capture());
+        DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
+        assertEquals(
+                EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
+                actualDecryptRequest.encryptionAlgorithmAsString());
+        assertEquals(
+                "alias/" + SESSION_DECRYPTION_KEY_PREVIOUS_ALIAS, actualDecryptRequest.keyId());
+        assertArrayEquals(
+                encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
+        assertEquals(11, claims.getClaims().size());
+        assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
+        assertEquals("ipv-core-stub", claims.getIssuer());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenAllKeyAliasesAreNotPresent() throws Exception {
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+        KMSRSADecrypter kmsRsaDecrypter = new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient);
+        JWEHeader header = createHeader();
+        Base64URL encryptedKey =
+                Base64URL.from(
+                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+        Base64URL cipherText =
+                Base64URL.from(
+                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+        when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                .thenThrow(new RuntimeException("primary key failed to decrypt"))
+                .thenThrow(new RuntimeException("secondary key failed to decrypt"))
+                .thenThrow(new RuntimeException("previous key failed to decrypt"));
+        assertThrows(
+                Exception.class,
+                () ->
+                        kmsRsaDecrypter.decrypt(
+                                header,
+                                encryptedKey,
+                                iv,
+                                cipherText,
+                                authTag,
+                                AAD.compute(header)));
+        verify(mockKmsClient, times(3)).decrypt(any(DecryptRequest.class));
+    }
+
+    @Test
     void shouldThrowExceptionWhenEncryptedKeyIsNull() throws ParseException {
+        KMSRSADecrypter kmsRsaDecrypter = new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient);
         JWEHeader header = createHeader();
         Base64URL testBase64URL = Base64URL.from("esS");
         assertThrows(
                 JOSEException.class,
                 () ->
-                        this.kmsRsaDecrypter.decrypt(
+                        kmsRsaDecrypter.decrypt(
                                 header,
                                 null,
                                 testBase64URL,
@@ -103,12 +280,13 @@ class KMSRSADecrypterTest {
 
     @Test
     void shouldThrowExceptionWhenInitVectorIsNull() throws ParseException {
+        KMSRSADecrypter kmsRsaDecrypter = new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient);
         JWEHeader header = createHeader();
         Base64URL testBase64URL = Base64URL.from("esS");
         assertThrows(
                 JOSEException.class,
                 () ->
-                        this.kmsRsaDecrypter.decrypt(
+                        kmsRsaDecrypter.decrypt(
                                 header,
                                 testBase64URL,
                                 null,
@@ -120,12 +298,13 @@ class KMSRSADecrypterTest {
 
     @Test
     void shouldThrowExceptionWhenAuthTagIsNull() throws ParseException {
+        KMSRSADecrypter kmsRsaDecrypter = new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient);
         JWEHeader header = createHeader();
         Base64URL testBase64URL = Base64URL.from("esS");
         assertThrows(
                 JOSEException.class,
                 () ->
-                        this.kmsRsaDecrypter.decrypt(
+                        kmsRsaDecrypter.decrypt(
                                 header,
                                 testBase64URL,
                                 testBase64URL,
@@ -137,12 +316,13 @@ class KMSRSADecrypterTest {
 
     @Test
     void shouldThrowExceptionWhenUnsupportedAlgorithmSupplied() throws ParseException {
+        KMSRSADecrypter kmsRsaDecrypter = new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient);
         JWEHeader header = createHeader(JWEAlgorithm.ECDH_1PU_A256KW);
         Base64URL testBase64URL = Base64URL.from("esS");
         assertThrows(
                 JOSEException.class,
                 () ->
-                        this.kmsRsaDecrypter.decrypt(
+                        kmsRsaDecrypter.decrypt(
                                 header,
                                 testBase64URL,
                                 testBase64URL,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Introduced logic to decrypt JWE content using primary, secondary, and previous key aliases behind a feature toggle.

- Added a fallback mechanism to attempt decryption with the secondary and previous aliases if the primary alias fails during execution of the key rotation step function.

- Added unit test cases to verify decryption using each key alias, including fallback scenarios.

### Why did it change

The KMSRSADecrypter has been updated to support the use of KMS aliases for decryption. This change is required for the key rotation pilot in Passport CRI.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1592](https://govukverify.atlassian.net/browse/LIME-1592)


## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed



[LIME-1592]: https://govukverify.atlassian.net/browse/LIME-1592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ