### PR TITLE
Change APIGateway into a AWS::ApiGateway::RestApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,5 @@ NOTE: The common-lambda stack has an extra `/pre-merge-create-auth-code` endpoin
 Run `detect-secrets scan --baseline .secrets.baseline` to check for potential leaked secrets.
 
 Use the keyword and secret exclusion lists in the baseline file to prevent the utility from flagging up specific strings.
+
+// to be removed

--- a/test-resources/infrastructure/public-api.yaml
+++ b/test-resources/infrastructure/public-api.yaml
@@ -143,19 +143,6 @@ x-amazon-apigateway-request-validators:
     validateRequestBody: true
     validateRequestParameters: true
 
-x-amazon-apigateway-policy:
-  Version: "2012-10-17"
-  Statement:
-    - Effect: "Deny"
-      Principal:
-        AWS:  "*"
-      Action: "execute-api:Invoke"
-      Resource: "execute-api:/*"
-      Condition:
-        StringNotEquals:
-          "aws:PrincipalAccount":
-            - "${AWS::AccountId}"
-
 components:
   securitySchemes:
     sigv4Reference:

--- a/test-resources/infrastructure/public-api.yaml
+++ b/test-resources/infrastructure/public-api.yaml
@@ -6,8 +6,6 @@ info:
 paths:
   /callback:
     get:
-      security:
-        - sigv4Reference: [ ]
       summary: handles Callback initiated by ipv-core-stub-aws-headless
       parameters:
         - name: authorizationCode

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -310,7 +310,7 @@ Resources:
   ApiGatewayStage:
     Type: AWS::ApiGateway::Stage
     Properties:
-      StageName: prod
+      StageName: !Ref Environment
       RestApiId:
         Ref: APIGateway
       MethodSettings:
@@ -398,7 +398,7 @@ Resources:
 
       # workaround for sam bug - see https://github.com/aws/serverless-application-model/issues/192#issuecomment-520893111
       # noinspection YamlUnresolvedReferences
-      Stage: !Ref Environment
+      Stage: !Ref ApiGatewayStage
 
   AuditEventsTableRole:
     Type: AWS::IAM::Role

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -307,10 +307,16 @@ Resources:
             Action: "execute-api:Invoke"
             Resource: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/${Environment}/*/*"
 
+  ApiGatewayDeployment:
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      RestApiId: !Ref APIGateway
+
   ApiGatewayStage:
     Type: AWS::ApiGateway::Stage
     Properties:
       StageName: !Ref Environment
+      DeploymentId: !Ref ApiGatewayDeployment
       RestApiId:
         Ref: APIGateway
       MethodSettings:

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -278,11 +278,41 @@ Resources:
         Enabled: true
 
   APIGateway:
-    Type: AWS::Serverless::Api
+    Type: AWS::ApiGateway::RestApi
     Properties:
       Description: APIGW for the test harness
-      StageName: !Ref Environment
-      TracingEnabled: true
+      Body:
+        openapi: 3.0.1
+        paths:
+          /never-created:
+            options: { }
+        Fn::Transform:
+          Name: AWS::Include
+          Parameters:
+            Location: public-api.yaml
+      Policy:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Deny
+            Principal: "*"
+            Action: "execute-api:Invoke"
+            Resource:
+              - !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/${Environment}/GET/events*"
+            Condition:
+              StringNotEquals:
+                "aws:PrincipalAccount":
+                  - !Sub "${AWS::AccountId}"
+          - Effect: Allow
+            Principal: "*"
+            Action: "execute-api:Invoke"
+            Resource: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/${Environment}/*/*"
+
+  ApiGatewayStage:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      StageName: prod
+      RestApiId:
+        Ref: APIGateway
       MethodSettings:
         - LoggingLevel: INFO
           ResourcePath: "/*"
@@ -305,15 +335,6 @@ Resources:
             protocol: $context.protocol
             responseLatency: $context.responseLatency
             responseLength: $context.responseLength
-      DefinitionBody:
-        openapi: 3.0.1
-        Fn::Transform:
-          Name: AWS::Include
-          Parameters:
-            Location: public-api.yaml
-      OpenApiVersion: 3.0.1
-      EndpointConfiguration:
-        Type: REGIONAL
 
   ApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
@@ -377,7 +398,7 @@ Resources:
 
       # workaround for sam bug - see https://github.com/aws/serverless-application-model/issues/192#issuecomment-520893111
       # noinspection YamlUnresolvedReferences
-      Stage: !Ref APIGateway.Stage
+      Stage: !Ref Environment
 
   AuditEventsTableRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## Proposed changes

### What changed
We are now using `AWS::ApiGateway::RestApi` for the APIGateway

### Why did it change
We have created a headless core stub but there is an explicit deny defined in the OpenAPI spec which means any request to the `/callback` endpoint will not work unless it was called from within the account. 

The deny was added for the `/events` endpoint but now that we have introduced more endpoints that should not be denied, we have updated the API definition to be a `AWS::ApiGateway::RestApi`. 

The reason this has been done is because on a `AWS::ApiGateway::RestApi` you can add endpoint specific policies, in this case, we deny everyone on the /events endpoint but allow the rest. 

In the case of the `/start` endpoint - this will still require sigv4 authentication. 