### PR TITLE
feat: change content type to text/plain for headless /callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ You can run against localhost as follows:
 
 `
 
-
 NOTE: The common-lambda stack has an extra `/pre-merge-create-auth-code` endpoint which it uses to create an authorization code which it needs as prerequisite to test certain paths, since it is not a CRI itself (since it just a collection of common endpoints used by CRI's).
 
 ## Check repo for secrets

--- a/test-resources/headless-core-stub/lambdas/callback/src/callback-handler.ts
+++ b/test-resources/headless-core-stub/lambdas/callback/src/callback-handler.ts
@@ -29,7 +29,7 @@ export class CallbackLambdaHandler implements LambdaInterface {
             const credentialEndpoint = `${audienceApi}/credential/issue`;
             const { statusCode, body } = await callback.invokeCredentialEndpoint(credentialEndpoint, access_token);
 
-            return { statusCode: statusCode, headers: { "Content-Type": "application/jwt" }, body };
+            return { statusCode: statusCode, headers: { "Content-Type": "text/plain" }, body };
         } catch (error: unknown) {
             const exception = error as Error;
             logger.error("Error occurred: ", exception.message);

--- a/test-resources/headless-core-stub/lambdas/callback/tests/callback-handler.test.ts
+++ b/test-resources/headless-core-stub/lambdas/callback/tests/callback-handler.test.ts
@@ -65,7 +65,7 @@ describe("callback-handler", () => {
         expect(response).toEqual({
             statusCode: 200,
             headers: {
-                "Content-Type": "application/jwt",
+                "Content-Type": "text/plain",
             },
             body: "vc.jwt.credential",
         });


### PR DESCRIPTION
## Proposed changes

### What changed
Changed the content type for /callback to text/plain

### Why did it change
Browser is trying to download the file as opposed to viewing it. 
