### PR TITLE
Fix: Test Resources - Round down time based JWT values

### DIFF
--- a/test-resources/headless-core-stub/lambdas/start/src/services/jwt-claims-set-service.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/services/jwt-claims-set-service.ts
@@ -76,7 +76,7 @@ export const validateClaimsSet = (claimsSet: JWTClaimsSet) => {
     }
 };
 
-const msToSeconds = (ms: number) => Math.round(ms / 1000);
+const msToSeconds = (ms: number) => Math.floor(ms / 1000);
 
 const defaultClaims = {
     name: [


### PR DESCRIPTION
## Proposed changes

### What changed

Changed Math.round to `Math.floor`

### Why did it change

Integration test validate the JWT returned from the start endpoint and are failing as the `nbf` can sometimes be in the future due to using `Math.round`.
