### PR TITLE
Split scan repo workflow

### DIFF
--- a/.github/workflows/scan-repo-test-resources.yml
+++ b/.github/workflows/scan-repo-test-resources.yml
@@ -1,4 +1,4 @@
-name: Scan repository
+name: Scan test resources repository
 
 on:
   pull_request:

--- a/.github/workflows/scan-repo-test-resources.yml
+++ b/.github/workflows/scan-repo-test-resources.yml
@@ -1,0 +1,52 @@
+name: Scan repository
+
+on:
+  pull_request:
+    paths:
+      - 'test-resources/**'
+      - '.github/**'
+  push:
+    branches: [main]
+  schedule:
+    # Every Monday at 9am
+    - cron: "0 9 * * 1"
+
+concurrency:
+  group: scan-repo-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  unit-tests-test-resources:
+    name: Test coverage
+    uses: ./.github/workflows/run-unit-tests-test-resources.yml
+    with:
+      coverage-report: true
+    secrets:
+      npm-token: ${{ secrets.GITHUB_TOKEN }}
+
+  sonarcloud-ts:
+    name: SonarCloud / TypeScript
+    needs: unit-tests-test-resources
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run SonarCloud scan
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@52a9e8e35980e6bcaf24d88180a61501e6f2605b
+        with:
+          projectBaseDir: test-resources
+          coverage-location: test-resources/coverage
+          coverage-artifact: ${{ needs.unit-tests-test-resources.outputs.coverage-artifact }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sonar-token: ${{ secrets.SONAR_TOKEN_TS }}
+
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Run CodeQL scan
+        uses: govuk-one-login/github-actions/code-quality/codeql@52a9e8e35980e6bcaf24d88180a61501e6f2605b
+        with:
+          languages: javascript-typescript

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -2,6 +2,8 @@ name: Scan repository
 
 on:
   pull_request:
+    paths-ignore:
+      - 'test-resources/**'
   push:
     branches: [main]
   schedule:
@@ -26,14 +28,6 @@ jobs:
     uses: ./.github/workflows/run-unit-tests-java.yml
     with:
       coverage-report: true
-
-  unit-tests-test-resources:
-    name: Test coverage
-    uses: ./.github/workflows/run-unit-tests-test-resources.yml
-    with:
-      coverage-report:  false
-    secrets:
-      npm-token: ${{ secrets.GITHUB_TOKEN }}
 
   sonarcloud-java:
     name: SonarCloud / Java

--- a/test-resources/sonar-project.properties
+++ b/test-resources/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=ipv-cri-common-lambdas-ts
+sonar.organization=govuk-one-login
+
+# Source files
+sonar.sources=.
+sonar.exclusions=tests/**/*
+
+# Tests
+sonar.tests=.
+sonar.test.inclusions=tests/**/*
+
+# Coverage
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Split the scan repo workflow into test resources and main so that only unit tests for the directory that have changed are run.

Note that I have added re-used the `ipv-cri-common-lambdas-ts` sonar project for test resources because there are limitation to how many projects we're able to have and there is a push to remove some.  

### Why did it change


