### PR TITLE
LIME-1626 Add new ipv-core client id - "ipv-core-3rd-party-stubs"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ integration-tests/bin/
 session/bin/
 
 *venv/
+
+.npmrc

--- a/deploy.sh
+++ b/deploy.sh
@@ -27,7 +27,7 @@ sam deploy --stack-name "$stack_name" \
   --tags \
   cri:component=ipv-cri-common-lambdas \
   cri:deployment-source=manual \
-  cri:stack-type=localdev \
+  cri:stack-type=dev \
   --parameter-overrides \
   Environment=dev \
   ${audit_event_name_prefix:+AuditEventNamePrefix=$audit_event_name_prefix} \

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -62,6 +62,9 @@ Conditions:
     - !Equals [!Ref Environment, build]
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
+  IsIpvCore3rdPartyStubEnvironment: !Equals
+    - !Ref Environment
+    - staging
   IsProdLikeEnvironment: !Or
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
@@ -1726,6 +1729,51 @@ Resources:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PreMergeDevOnlyApi}-private-AccessLogs
       RetentionInDays: 30
 
+  ##################################################################################################
+  # ipv-core-3rd-party-stubs clientId configuration (real ipv-core + real cri's + 3rd-party-stubs Only Staging)
+  #################################################################################################
+  IPVCore3rdPartyStubsAudienceParameter:
+    Condition: IsIpvCore3rdPartyStubEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/clients/ipv-core-3rd-party-stubs/jwtAuthentication/audience"
+      Type: String
+      Value:
+        !FindInMap [CriAudienceMapping, !Ref CriIdentifier, !Ref Environment]
+
+  IPVCore3rdPartyStubsPublicSigningJwkBase64Parameter:
+    Condition: IsIpvCore3rdPartyStubEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/clients/ipv-core-3rd-party-stubs/jwtAuthentication/publicSigningJwkBase64"
+      Type: String
+      Value:
+        !FindInMap [IPVCore1PublicSigningJwkBase64Mapping, Environment,!Ref "Environment"]
+
+  IPVCore3rdPartyStubsIssuerParameter:
+    Condition: IsIpvCore3rdPartyStubEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/clients/ipv-core-3rd-party-stubs/jwtAuthentication/issuer"
+      Type: String
+      Value: !FindInMap [IPVCore1IssuerMapping, Environment, !Ref "Environment"]
+
+  IPVCore3rdPartyStubsRedirectURIParameter:
+    Condition: IsIpvCore3rdPartyStubEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/clients/ipv-core-3rd-party-stubs/jwtAuthentication/redirectUri"
+      Type: String
+      Value:
+        !FindInMap [IPVCore1RedirectURIMapping, !Ref CriIdentifier, !Ref Environment ]
+
+  IPVCore3rdPartyStubsAuthenticationAlgParameter:
+    Condition: IsIpvCore3rdPartyStubEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/clients/ipv-core-3rd-party-stubs/jwtAuthentication/authenticationAlg"
+      Type: String
+      Value: ES256
 
   ##################################################################################################
   # ipv-core-stub-aws-headless clientId configuration


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add new ipv-core client id - "ipv-core-3rd-party-stubs"

	- Added .npmrc to .gitignore to mitigate leaking github tokens should .npmrc be located in the repo
	- - Pre-commit uses the event catalog npm package which needs a token to install
	- Unable to deploy into dev via deploy.sh

### Why did it change

ipv-core-3rd-party-stubs - To enable an IPV-Core end to end journey with CRI using third-party stubs

.npmrc to .gitignore - Pre-commit uses the event catalog npm package which needs a token to instal. To avoid leaking this should this be added to a repo based .npmrc

"localdev" changed to "dev" as this prevents deploying into dev via deploy.sh

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1626](https://govukverify.atlassian.net/browse/LIME-1626)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1626]: https://govukverify.atlassian.net/browse/LIME-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ