### PR TITLE
OJ-3049: Unpin sam-version from preview action

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -53,7 +53,6 @@ jobs:
           template: infrastructure/lambda/template.yaml
           cache-name: common-lambdas-${{ steps.vars.outputs.sha_short }}
           pull-repository: false
-          sam-version: 1.132.0
 
   deploy:
     name: Deploy stack

--- a/.github/workflows/test-resources-preview.yml
+++ b/.github/workflows/test-resources-preview.yml
@@ -52,7 +52,6 @@ jobs:
         with:
           template: test-resources/infrastructure/template.yaml
           cache-name: test-resources-${{ steps.vars.outputs.sha_short }}
-          sam-version: 1.132.0
 
   deploy:
     name: Deploy stack


### PR DESCRIPTION
## Proposed changes

### What changed

Unpin sam version from preview stack. 
Reverts https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/389 but keeps the newer version of the action.

### Why did it change

No longer requires pinning as the linting bug was fixed in Sam CLI 1.135.0 which ubuntu-latest image now uses.

### Issue tracking

- [OJ-3049](https://govukverify.atlassian.net/browse/OJ-3049)

[OJ-3049]: https://govukverify.atlassian.net/browse/OJ-3049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ