### PR TITLE
OJ-3136: Include hashed kid in JWT header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8038,6 +8038,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "dev": true,
@@ -14286,6 +14292,7 @@
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
         "aws-sdk-client-mock": "4.1.0",
+        "crypto": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "esbuild": "0.25.1",
         "jose": "5.10.0"

--- a/test-resources/headless-core-stub/lambdas/start/src/start-handler.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/start-handler.ts
@@ -5,8 +5,9 @@ import middy from "@middy/core";
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
 import { JWK, JWTPayload, KeyLike } from "jose";
 import { signJwt } from "../../../utils/src/crypto/signer";
-import { ClientConfiguration } from "../../../utils/src/services/client-configuration";
 import { handleErrorResponse } from "./../../../utils/src/errors/error-response";
+import { getHashedKid } from "./../../../utils/src/hashing";
+import { ClientConfiguration } from "../../../utils/src/services/client-configuration";
 import { generateJwtClaimsSet, parseJwtClaimsSetOverrides, validateClaimsSet } from "./services/jwt-claims-set-service";
 import { encryptSignedJwt, getPublicEncryptionKey } from "./services/signing-service";
 import { ClaimsSetOverrides } from "./types/claims-set-overrides";
@@ -26,7 +27,11 @@ export class StartLambdaHandler implements LambdaInterface {
             validateClaimsSet(jwtClaimsSet);
 
             const signingKey: JWK = JSON.parse(ssmParameters["privateSigningKey"]);
-            const jwtHeader = { alg: "ES256", typ: "JWT", kid: signingKey.kid };
+            const jwtHeader = {
+                alg: "ES256",
+                typ: "JWT",
+                ...(signingKey.kid && { kid: getHashedKid(signingKey.kid) }),
+            };
             const signedJwt = await signJwt(jwtClaimsSet as JWTPayload, signingKey, jwtHeader);
 
             const publicEncryptionKey: KeyLike = await getPublicEncryptionKey();

--- a/test-resources/headless-core-stub/lambdas/start/src/start-handler.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/start-handler.ts
@@ -26,8 +26,8 @@ export class StartLambdaHandler implements LambdaInterface {
             validateClaimsSet(jwtClaimsSet);
 
             const signingKey: JWK = JSON.parse(ssmParameters["privateSigningKey"]);
-
-            const signedJwt = await signJwt(jwtClaimsSet as JWTPayload, signingKey);
+            const jwtHeader = { alg: "ES256", typ: "JWT", kid: signingKey.kid };
+            const signedJwt = await signJwt(jwtClaimsSet as JWTPayload, signingKey, jwtHeader);
 
             const publicEncryptionKey: KeyLike = await getPublicEncryptionKey();
 

--- a/test-resources/headless-core-stub/utils/src/hashing/index.ts
+++ b/test-resources/headless-core-stub/utils/src/hashing/index.ts
@@ -1,0 +1,7 @@
+import { createHash } from "crypto";
+
+export const getHashedKid = (keyId: string) => {
+    const kidBytes = Buffer.from(keyId, "utf8");
+    const hash = createHash("sha256").update(kidBytes).digest();
+    return Buffer.from(hash).toString("hex");
+};

--- a/test-resources/headless-core-stub/utils/tests/hashing/index.test.ts
+++ b/test-resources/headless-core-stub/utils/tests/hashing/index.test.ts
@@ -1,0 +1,10 @@
+import { getHashedKid } from "../../src/hashing";
+
+describe("hashing", () => {
+    describe("getHashedKid", () => {
+        it("returns a hashed key id", () => {
+            const result = getHashedKid("ipv-core-stub-2-from-mkjwk.org");
+            expect(result).toEqual("74c5b00d698a18178a738f5305ee67f9d50fc620f8be6b89d94638fa16a4c828"); // pragma: allowlist secret
+        });
+    });
+});

--- a/test-resources/integration-tests/start/start-happy.test.ts
+++ b/test-resources/integration-tests/start/start-happy.test.ts
@@ -46,7 +46,7 @@ describe("happy path core stub start endpoint", () => {
 
         const jwtBuffer = await jweDecrypter.decryptJwe(request);
         const jwtVerifier = jwtVerifierFactory.create(authenticationAlg, publicSigningJwkBase64);
-        const payload = await jwtVerifier.verify(
+        const verifyResult = await jwtVerifier.verify(
             jwtBuffer,
             new Set([ClaimNames.EXPIRATION_TIME, ClaimNames.SUBJECT, ClaimNames.NOT_BEFORE, ClaimNames.STATE]),
             new Map([
@@ -55,11 +55,15 @@ describe("happy path core stub start endpoint", () => {
             ]),
         );
 
+        // console.log("protectedHeader", verifyResult?.protectedHeader);
         expect(data.status).toBe(200);
         expect(client_id).toBe(clientId);
-        expect(payload?.iss).toEqual(iss);
-        expect(payload?.aud).toEqual(aud);
-        expect(payload?.shared_claims).toEqual({
+        expect(verifyResult?.protectedHeader.alg).toEqual("ES256");
+        expect(verifyResult?.protectedHeader.typ).toEqual("JWT");
+        expect(verifyResult?.protectedHeader.kid).toEqual("ipv-core-stub-2-from-mkjwk.org");
+        expect(verifyResult?.payload.iss).toEqual(iss);
+        expect(verifyResult?.payload.aud).toEqual(aud);
+        expect(verifyResult?.payload.shared_claims).toEqual({
             name: [
                 {
                     nameParts: [
@@ -85,7 +89,7 @@ describe("happy path core stub start endpoint", () => {
                 },
             ],
         });
-        expect(payload?.state).toEqual(defaultState);
+        expect(verifyResult?.payload.state).toEqual(defaultState);
     });
 
     it("returns overridden shared claims if provided", async () => {
@@ -136,7 +140,7 @@ describe("happy path core stub start endpoint", () => {
 
         const jwtBuffer = await jweDecrypter.decryptJwe(request);
         const jwtVerifier = jwtVerifierFactory.create(authenticationAlg, publicSigningJwkBase64);
-        const payload = await jwtVerifier.verify(
+        const verifyResult = await jwtVerifier.verify(
             jwtBuffer,
             new Set([ClaimNames.EXPIRATION_TIME, ClaimNames.SUBJECT, ClaimNames.NOT_BEFORE, ClaimNames.STATE]),
             new Map([
@@ -147,9 +151,12 @@ describe("happy path core stub start endpoint", () => {
 
         expect(data.status).toBe(200);
         expect(client_id).toBe(clientId);
-        expect(payload?.iss).toEqual(iss);
-        expect(payload?.aud).toEqual(aud);
-        expect(payload?.shared_claims).toEqual(sharedClaimsOverrides);
-        expect(payload?.state).toEqual(stateOverride);
+        expect(verifyResult?.protectedHeader.alg).toEqual("ES256");
+        expect(verifyResult?.protectedHeader.typ).toEqual("JWT");
+        expect(verifyResult?.protectedHeader.kid).toEqual("ipv-core-stub-2-from-mkjwk.org");
+        expect(verifyResult?.payload.iss).toEqual(iss);
+        expect(verifyResult?.payload.aud).toEqual(aud);
+        expect(verifyResult?.payload.shared_claims).toEqual(sharedClaimsOverrides);
+        expect(verifyResult?.payload.state).toEqual(stateOverride);
     });
 });

--- a/test-resources/integration-tests/start/start-happy.test.ts
+++ b/test-resources/integration-tests/start/start-happy.test.ts
@@ -55,12 +55,14 @@ describe("happy path core stub start endpoint", () => {
             ]),
         );
 
-        // console.log("protectedHeader", verifyResult?.protectedHeader);
         expect(data.status).toBe(200);
         expect(client_id).toBe(clientId);
         expect(verifyResult?.protectedHeader.alg).toEqual("ES256");
         expect(verifyResult?.protectedHeader.typ).toEqual("JWT");
-        expect(verifyResult?.protectedHeader.kid).toEqual("ipv-core-stub-2-from-mkjwk.org");
+        // ipv-core-stub-2-from-mkjwk.org hashed
+        expect(verifyResult?.protectedHeader.kid).toEqual(
+            "74c5b00d698a18178a738f5305ee67f9d50fc620f8be6b89d94638fa16a4c828", // pragma: allowlist secret
+        );
         expect(verifyResult?.payload.iss).toEqual(iss);
         expect(verifyResult?.payload.aud).toEqual(aud);
         expect(verifyResult?.payload.shared_claims).toEqual({
@@ -153,7 +155,10 @@ describe("happy path core stub start endpoint", () => {
         expect(client_id).toBe(clientId);
         expect(verifyResult?.protectedHeader.alg).toEqual("ES256");
         expect(verifyResult?.protectedHeader.typ).toEqual("JWT");
-        expect(verifyResult?.protectedHeader.kid).toEqual("ipv-core-stub-2-from-mkjwk.org");
+        // ipv-core-stub-2-from-mkjwk.org hashed
+        expect(verifyResult?.protectedHeader.kid).toEqual(
+            "74c5b00d698a18178a738f5305ee67f9d50fc620f8be6b89d94638fa16a4c828", // pragma: allowlist secret
+        );
         expect(verifyResult?.payload.iss).toEqual(iss);
         expect(verifyResult?.payload.aud).toEqual(aud);
         expect(verifyResult?.payload.shared_claims).toEqual(sharedClaimsOverrides);

--- a/test-resources/package.json
+++ b/test-resources/package.json
@@ -27,6 +27,7 @@
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
         "aws-sdk-client-mock": "4.1.0",
+        "crypto": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "esbuild": "0.25.1",
         "jose": "5.10.0"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Include hashed kid in JWT header

### Why did it change

- To more accurately mock core
- So that the kid can be used to find the signing key on our mock jwks endpoint that is also going to hash the kids

### Screenshots

JWTs produced by /start can still be used in the session endpoint (test)
<img width="1146" alt="image" src="https://github.com/user-attachments/assets/0ac46b7e-8853-49aa-8d6d-f2834bc5bee9" />

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3136](https://govukverify.atlassian.net/browse/OJ-3136)