### PR TITLE
LIME-1443 DL CRI enable SnapStart in common-api lambdas - integration/production

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -357,8 +357,8 @@ Mappings:
       dev: PublishedVersions
       build: PublishedVersions
       staging: PublishedVersions
-      integration: None
-      production: None
+      integration: PublishedVersions
+      production: PublishedVersions
     di-ipv-cri-passport-api:
       dev: PublishedVersions
       build: PublishedVersions


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enable SnapStart on the common-api Java Lambdas for DL CRI

### Why did it change

SnapStart is enabled from dev through staging, this enables it for integration and production on the common-api lambdas.

### Issue tracking

- [LIME-1443](https://govukverify.atlassian.net/browse/LIME-1443)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1443]: https://govukverify.atlassian.net/browse/LIME-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ