### PR TITLE
LIME-1630 Added metric for Oauth alias decryption failure

### DIFF
--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/handler/SessionHandler.java
@@ -66,15 +66,16 @@ public class SessionHandler
         this.sessionService =
                 new SessionService(
                         configurationService, clientProviderFactory.getDynamoDbEnhancedClient());
+        this.eventProbe = new EventProbe();
         this.sessionRequestService =
                 new SessionRequestService(
                         configurationService,
                         clientProviderFactory.getKMSClient(),
-                        sharedObjectMapper);
+                        sharedObjectMapper,
+                        eventProbe);
         this.personIdentityService =
                 new PersonIdentityService(
                         configurationService, clientProviderFactory.getDynamoDbEnhancedClient());
-        this.eventProbe = new EventProbe();
         this.auditService =
                 new AuditService(
                         clientProviderFactory.getSqsClient(),

--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestService.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestService.java
@@ -16,6 +16,7 @@ import uk.gov.di.ipv.cri.common.library.exception.ClientConfigurationException;
 import uk.gov.di.ipv.cri.common.library.exception.SessionValidationException;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.JWTVerifier;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.common.library.util.deserializers.PiiRedactingDeserializer;
 
 import java.net.URI;
@@ -43,7 +44,8 @@ public class SessionRequestService {
     public SessionRequestService(
             ConfigurationService configurationService,
             KmsClient kmsClient,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            EventProbe eventProbe) {
         this.configurationService = configurationService;
         this.objectMapper = objectMapper;
         this.objectMapper
@@ -58,7 +60,9 @@ public class SessionRequestService {
         this.jwtDecrypter =
                 new JWTDecrypter(
                         new KMSRSADecrypter(
-                                this.configurationService.getKmsEncryptionKeyId(), kmsClient));
+                                this.configurationService.getKmsEncryptionKeyId(),
+                                kmsClient,
+                                eventProbe));
     }
 
     public SessionRequestService(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Implement an alarm when no key alias available to the CRI that matches the encryption key used to create the encrypted payload. 

### What changed

- Updated KMSRSADecrypter with new metric 
- Required event probe to be added to Session handler and Service
- Unit tests amended to include event probe mock


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1630](https://govukverify.atlassian.net/browse/LIME-1630)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->



[LIME-1630]: https://govukverify.atlassian.net/browse/LIME-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ