### PR TITLE
LIME-1622 - disabling provisioned concurrency (build/staging)

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -297,8 +297,8 @@ Mappings:
       production: 0
     di-ipv-cri-fraud-api:
       dev: 0
-      build: 1
-      staging: 1
+      build: 0
+      staging: 0
       integration: 1
       production: 1
     di-ipv-cri-kbv-api:


### PR DESCRIPTION
### What changed
Disabled Provisioned Concurrency for Fraud, this PR should be merged before the fast follow which enables snapstart - https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/453
