### PR TITLE
LIME-1622 - enabling snapstart (build/staging)

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -342,9 +342,9 @@ Mappings:
       integration: PublishedVersions
       production: PublishedVersions
     di-ipv-cri-fraud-api:
-      dev: None
-      build: None
-      staging: None
+      dev: PublishedVersions
+      build: PublishedVersions
+      staging: PublishedVersions
       integration: None
       production: None
     di-ipv-cri-kbv-api:


### PR DESCRIPTION
### What changed
Enabling snapstart, this PR should be a fast follow to disabling provisioned concurrency for Fraud - https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/452