### PR TITLE
fix-cache-control-header

### DIFF
--- a/test-resources/headless-core-stub/lambdas/mock-jwks/src/mock-jwk-handler.ts
+++ b/test-resources/headless-core-stub/lambdas/mock-jwks/src/mock-jwk-handler.ts
@@ -18,6 +18,9 @@ export class MockJwkHandler implements LambdaInterface {
                 return {
                     statusCode: 200,
                     body: JSON.stringify(jwks),
+                    headers: {
+                        "Cache-Control": "max-age=900",
+                    },
                 };
             }
 

--- a/test-resources/infrastructure/public-api.yaml
+++ b/test-resources/infrastructure/public-api.yaml
@@ -10,22 +10,6 @@ paths:
       description: |
         Return the current valid public keys (JSON Web Key Set) used to
         verify that request JAR are signed by core-stub.
-      headers:
-        Cache-Control:
-          schema:
-            type: "string"
-        Content-Type:
-          schema:
-            type: "string"
-        Strict-Transport-Security:
-          schema:
-            type: "string"
-        X-Content-Type-Options:
-          schema:
-            type: "string"
-        X-Frame-Options:
-          schema:
-            type: "string"
       responses:
         "200":
           description: OK

--- a/test-resources/infrastructure/public-api.yaml
+++ b/test-resources/infrastructure/public-api.yaml
@@ -29,12 +29,6 @@ paths:
       responses:
         "200":
           description: OK
-          responseParameters:
-            method.response.header.Cache-Control: "'max-age=900'"
-            method.response.header.Strict-Transport-Security: "'max-age=31536000; includeSubDomains'"
-            method.response.header.X-Content-Type-Options: "'nosniff'"
-            method.response.header.X-Frame-Options: "'DENY'"
-            method.response.header.Content-Type: "'application/json'"
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Proposed changes

### What  and why did it change
Removed the `responseParameters` because AWS_PROXY integration type ignores responseParameters, so the headers defined here were not being set. The header is now being returned by the Lambda directly. 

Removed the other headers inside responseParameters as they are not needed. 

**Screenshot**
<img width="339" alt="Screenshot 2025-05-02 at 15 42 48" src="https://github.com/user-attachments/assets/239074b6-a204-43e6-9626-e7386ddf1c5b" />

