### PR TITLE
OJ-2972: bump cri-lib and disable public jwk consumption in > dev for address

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
 		junit                    : "5.10.1",
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
-		cri_common_lib           : "5.0.0",
+		cri_common_lib           : "5.0.1",
 		webcompere_version       : "2.1.7",
 	]
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -172,8 +172,8 @@ Mappings:
   KeyRotationEnabled:
     di-ipv-cri-address-api:
       dev: true
-      build: true
-      staging: true
+      build: false
+      staging: false
       integration: false
       production: false
     di-ipv-cri-fraud-api:


### PR DESCRIPTION
## Proposed changes

### What changed
cri-lib to 5.0.1 contains a NPE fix
disabled public jwk consumption in higher envs as [OJ-3196](https://govukverify.atlassian.net/browse/OJ-3169)

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
- [OJ-2972](https://govukverify.atlassian.net/browse/OJ-2972)


[OJ-2972]: https://govukverify.atlassian.net/browse/OJ-2972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ