### PR TITLE
OJ-3169: Add hashed KID header to client_assertion for /token call

### DIFF
--- a/test-resources/headless-core-stub/lambdas/callback/src/services/private-key-jwt-helper.ts
+++ b/test-resources/headless-core-stub/lambdas/callback/src/services/private-key-jwt-helper.ts
@@ -1,6 +1,8 @@
+import { JWK, JWTPayload } from "jose";
 import { v4 as uuidv4 } from "uuid";
 import { signJwt } from "../../../../utils/src/crypto/signer";
-import { JWK, JWTPayload } from "jose";
+import { getHashedKid } from "../../../../utils/src/hashing";
+
 export const generatePrivateJwtParams = async (
     clientId: string,
     authorizationCode: string,
@@ -16,7 +18,13 @@ export const generatePrivateJwtParams = async (
         jti: uuidv4(),
     };
 
-    const signedJwt = await signJwt(signingClaims, privateJwtKey);
+    const jwtHeader = {
+        alg: "ES256",
+        typ: "JWT",
+        ...(privateJwtKey.kid && { kid: getHashedKid(privateJwtKey.kid) }),
+    };
+
+    const signedJwt = await signJwt(signingClaims, privateJwtKey, jwtHeader);
 
     return new URLSearchParams([
         ["client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add hashed KID header to client_assertion for /token call

### Why did it change

Because the token lambda needs to know the KID of the key that was used to sign the JWT so that it can find the right key from the jkws endpoint

### Screenshots
<img width="677" alt="image" src="https://github.com/user-attachments/assets/5ab49a6c-d1f0-472a-85a0-e2482ce4df4d" />

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3169](https://govukverify.atlassian.net/browse/OJ-3169)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


