### PR TITLE
feat: add StackId as the description for ApiGatewayDeployment

### DIFF
--- a/test-resources/infrastructure/public-api.yaml
+++ b/test-resources/infrastructure/public-api.yaml
@@ -19,6 +19,8 @@ paths:
                 $ref: "#/components/schemas/JsonWebKeySet"
         "404":
           description: Not Found
+        "400":
+          description: Bad request
         "500":
           description: Internal server error
       x-amazon-apigateway-integration:

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -350,6 +350,7 @@ Resources:
   ApiGatewayStage:
     Type: AWS::ApiGateway::Stage
     Properties:
+      Description: !Ref AWS::StackId
       StageName: !Ref Environment
       DeploymentId: !Ref ApiGatewayDeployment
       RestApiId:

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -344,6 +344,7 @@ Resources:
   ApiGatewayDeployment:
     Type: AWS::ApiGateway::Deployment
     Properties:
+      Description: !Ref AWS::StackId
       RestApiId: !Ref APIGateway
 
   ApiGatewayStage:


### PR DESCRIPTION
## Proposed changes

### Why did it change
The API did not redeploy when the OpenAPI spec was changed which meant we manually have to redeploy. This PR adds the StackId to the description because the StackId changes everytime the stack is updated, which in return will cause the resources to redeploy for us. 
