### PR TITLE
LIME-1447 - disabling provisioned concurrency (int/prod)

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -387,8 +387,8 @@ Mappings:
       dev: 0
       build: 0
       staging: 0
-      integration: 1
-      production: 1
+      integration: 0
+      production: 0
     di-ipv-cri-kbv-api:
       dev: 0
       build: 0


### PR DESCRIPTION
### What changed
This PR is to disable provisioned concurrency for frauds common-lambdas, there will be a fast follow PR to enable snapstart - https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/467