### PR TITLE
LIME-1447 - enabling snapstart (int/prod)

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -433,8 +433,8 @@ Mappings:
       dev: PublishedVersions
       build: PublishedVersions
       staging: PublishedVersions
-      integration: None
-      production: None
+      integration: PublishedVersions
+      production: PublishedVersions
     di-ipv-cri-kbv-api:
       dev: None
       build: None


### PR DESCRIPTION
### What changed
This PR is to enabled Snapstart for Frauds common lambdas in integration and production and should be merged as a fast follow to this PR which disabled provisioned concurrency - https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/466
