### PR TITLE
OJ-3077: Add JWKS Endpoint for TypeScript

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -183,7 +183,7 @@ Mappings:
       integration: false
       production: false
     di-ipv-cri-kbv-api:
-      dev: false
+      dev: true
       build: false
       staging: false
       integration: false
@@ -842,6 +842,8 @@ Resources:
           SQS_AUDIT_EVENT_QUEUE_URL:
             Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
           CRI_IDENTIFIER: !Sub "${CriIdentifier}"
+          ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK: !FindInMap [ KeyRotationEnabled, !Ref CriIdentifier, !Ref Environment]
+          PUBLIC_JWKS_ENDPOINT: !FindInMap [ JwkEndpoint, !Ref CriIdentifier, !Ref Environment ]
       AutoPublishAlias: live
       AutoPublishAliasAllProperties: true
       Policies:
@@ -1115,6 +1117,8 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-access-token-2"
+          ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK: !FindInMap [ KeyRotationEnabled, !Ref CriIdentifier, !Ref Environment]
+          PUBLIC_JWKS_ENDPOINT: !FindInMap [ JwkEndpoint, !Ref CriIdentifier, !Ref Environment ]
       AutoPublishAlias: live
       AutoPublishAliasAllProperties: true
       Policies:

--- a/lambdas/src/common/security/jwt-verifier.ts
+++ b/lambdas/src/common/security/jwt-verifier.ts
@@ -1,7 +1,11 @@
-import { importJWK, JWTPayload, jwtVerify } from "jose";
+import { createLocalJWKSet, importJWK, JWTPayload, jwtVerify } from "jose";
 import { JWTVerifyOptions } from "jose/dist/types/jwt/verify";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { JwtVerificationConfig } from "../../types/jwt-verification-config";
+import { JWKS } from "../../types/jwks";
+
+let cachedJWKS: JWKS | null = null;
+let cachedJWKSExpiry: number | null = null;
 
 export enum ClaimNames {
     ISSUER = "iss",
@@ -18,46 +22,117 @@ export enum ClaimNames {
 
 export class JwtVerifier {
     static ClaimNames = ClaimNames;
+    private readonly usePublicJwksEndpoint;
+    private readonly publicJwksEndpoint;
+
     constructor(
         private jwtVerifierConfig: JwtVerificationConfig,
         private logger: Logger,
-    ) {}
+    ) {
+        this.usePublicJwksEndpoint = process.env.ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK ?? "false";
+        this.publicJwksEndpoint = process.env.PUBLIC_JWKS_ENDPOINT ?? "";
+    }
 
     public async verify(
         encodedJwt: Buffer,
         mandatoryClaims: Set<string>,
         expectedClaimValues: Map<string, string>,
     ): Promise<JWTPayload | null> {
+        const jwtVerifyOptions = this.createJwtVerifyOptions(expectedClaimValues);
+        if (this.usePublicJwksEndpoint === "true") {
+            return await this.verifyWithJwksEndpoint(encodedJwt, mandatoryClaims, jwtVerifyOptions);
+        } else {
+            this.logger.info("Using public JWKS endpoint is disabled");
+            return await this.verifyWithJwksParam(encodedJwt, mandatoryClaims, jwtVerifyOptions);
+        }
+    }
+
+    private async verifyWithJwksEndpoint(
+        encodedJwt: Buffer,
+        mandatoryClaims: Set<string>,
+        jwtVerifyOptions: JWTVerifyOptions,
+    ) {
+        this.logger.info("Using JWKS endpoint: " + this.publicJwksEndpoint);
+        try {
+            if (this.publicJwksEndpoint === "") {
+                throw new Error("PUBLIC_JWKS_ENDPOINT env variable has not been set");
+            }
+
+            if (cachedJWKS && cachedJWKSExpiry && cachedJWKSExpiry >= Date.now()) {
+                this.logger.info("Using locally cached JWKs from " + this.publicJwksEndpoint);
+            } else {
+                this.logger.info("Fetching new JWKS from " + this.publicJwksEndpoint);
+                await this.fetchAndCacheJWKS(new URL(this.publicJwksEndpoint));
+            }
+
+            const localJWKSet = createLocalJWKSet(cachedJWKS!);
+            const { payload } = await jwtVerify(encodedJwt.toString(), localJWKSet, jwtVerifyOptions);
+            this.verifyMandatoryClaims(mandatoryClaims, payload);
+            this.logger.info("Sucessfully verified JWT using Public JWKS Endpoint");
+            return payload;
+        } catch (error) {
+            this.clearJWKSCache();
+            this.logger.error("Failed to call JWKS endpoint, attempting with params.", error as Error);
+            return this.verifyWithJwksParam(encodedJwt, mandatoryClaims, jwtVerifyOptions);
+        }
+    }
+
+    private async fetchAndCacheJWKS(jwksUrl: URL) {
+        const jwksResponse = await fetch(jwksUrl);
+        if (!jwksResponse.ok) {
+            throw new Error("Error recieved from the JWKS endpoint, status recieved: " + jwksResponse.status);
+        }
+
+        cachedJWKS = await jwksResponse.json();
+        cachedJWKSExpiry = this.parseCacheControlHeader(jwksResponse.headers.get("Cache-Control"));
+        this.logger.info("JWKS cache has been updated to " + cachedJWKSExpiry);
+    }
+
+    private parseCacheControlHeader(cacheControlHeaderValue: string | null) {
+        const matches = cacheControlHeaderValue?.match(/max-age=(\d+)/);
+        const maxAgeSeconds = matches ? parseInt(matches[1], 10) : -1;
+        return Date.now() + maxAgeSeconds * 1000;
+    }
+
+    public clearJWKSCache() {
+        cachedJWKS = null;
+        cachedJWKSExpiry = null;
+    }
+
+    private async verifyWithJwksParam(
+        encodedJwt: Buffer,
+        mandatoryClaims: Set<string>,
+        jwtVerifyOptions: JWTVerifyOptions,
+    ) {
+        this.logger.info("Attempting to verify JWT using Public JWKS parameter");
         try {
             const signingPublicJwkBase64 = this.jwtVerifierConfig.publicSigningJwk;
             const signingAlgorithm = this.jwtVerifierConfig.jwtSigningAlgorithm;
             const signingPublicJwk = JSON.parse(Buffer.from(signingPublicJwkBase64, "base64").toString("utf8"));
             const publicKey = await importJWK(signingPublicJwk, signingPublicJwk?.alg || signingAlgorithm);
-
-            const jwtVerifyOptions = this.createJwtVerifyOptions(signingAlgorithm, expectedClaimValues);
             const { payload } = await jwtVerify(encodedJwt, publicKey, jwtVerifyOptions);
-
-            if (!mandatoryClaims || mandatoryClaims?.size === 0) throw new Error("No mandatory claims provided");
-
-            mandatoryClaims?.forEach((mandatoryClaim) => {
-                if (!payload[mandatoryClaim]) {
-                    throw new Error(`Claims-set missing mandatory claim: ${mandatoryClaim}`);
-                }
-            });
-
+            this.verifyMandatoryClaims(mandatoryClaims, payload);
+            this.logger.info("Sucessfully verified JWT using Public JWKS Parameter");
             return payload;
         } catch (error) {
-            this.logger.error("JWT verification failed", error as Error);
+            this.logger.error("JWT verification failed with JWKS parameter", error as Error);
             return null;
         }
     }
 
-    private createJwtVerifyOptions(
-        signingAlgorithm: string,
-        expectedClaimValues: Map<string, string>,
-    ): JWTVerifyOptions {
+    private verifyMandatoryClaims(mandatoryClaims: Set<string>, payload: JWTPayload) {
+        if (!mandatoryClaims || mandatoryClaims?.size === 0) throw new Error("No mandatory claims provided");
+
+        mandatoryClaims?.forEach((mandatoryClaim) => {
+            if (!payload[mandatoryClaim]) {
+                throw new Error(`Claims-set missing mandatory claim: ${mandatoryClaim}`);
+            }
+        });
+    }
+
+    private createJwtVerifyOptions(expectedClaimValues: Map<string, string>): JWTVerifyOptions {
         return {
-            algorithms: [signingAlgorithm],
+            algorithms: [this.jwtVerifierConfig.jwtSigningAlgorithm],
             audience: expectedClaimValues.get(JwtVerifier.ClaimNames.AUDIENCE),
             issuer: expectedClaimValues.get(JwtVerifier.ClaimNames.ISSUER),
             subject: expectedClaimValues.get(JwtVerifier.ClaimNames.SUBJECT),

--- a/lambdas/src/types/jwks.ts
+++ b/lambdas/src/types/jwks.ts
@@ -1,0 +1,5 @@
+import { JWK } from "jose";
+
+export interface JWKS {
+    keys: JWK[];
+}

--- a/lambdas/tests/unit/common/security/jwt-verifier.test.ts
+++ b/lambdas/tests/unit/common/security/jwt-verifier.test.ts
@@ -8,6 +8,7 @@ import { JwkKeyExportOptions } from "crypto";
 jest.mock("jose", () => ({
     importJWK: jest.fn(),
     jwtVerify: jest.fn(),
+    createLocalJWKSet: jest.fn(),
 }));
 
 type JwkKeyExtendedExportOptions = JwkKeyExportOptions & {
@@ -19,316 +20,562 @@ type JwkKeyExtendedExportOptions = JwkKeyExportOptions & {
 
 describe("jwt-verifier.ts", () => {
     let logger: Logger;
-    describe("JwtVerifier", () => {
-        let signingPublicJwk: jose.JWK;
-        let jwtVerifierConfig: JwtVerificationConfig;
-        let jwtVerifyOptions: JwkKeyExtendedExportOptions;
 
-        beforeEach(() => {
-            signingPublicJwk = {
-                alg: "ES256",
-                kty: "kty",
-                use: "use",
-                x: "x",
-                y: "y",
-            };
-            jwtVerifierConfig = {
-                publicSigningJwk: "publicSigningJwk",
-                jwtSigningAlgorithm: "ES256",
-            };
-            jwtVerifyOptions = {
-                algorithms: ["ES256"],
-                audience: "some-audience",
-                issuer: "some-issuer",
-                subject: "some-subject",
-            } as unknown as JwkKeyExtendedExportOptions;
-        });
+    beforeEach(() => {
+        logger = {
+            error: jest.fn(),
+            info: jest.fn(),
+        } as unknown as Logger;
+    });
+
+    describe("JwtVerifier", () => {
+        let jwtVerifier: JwtVerifier;
 
         describe("verify", () => {
-            let publicKey: Uint8Array;
-            let jwtVerifier: JwtVerifier;
+            let jwtVerifierConfig: JwtVerificationConfig;
+            let jwtVerifyOptions: JwkKeyExtendedExportOptions;
 
             beforeEach(() => {
-                logger = {
-                    error: jest.fn(),
-                } as unknown as Logger;
-                publicKey = new Uint8Array([3, 101, 120, 26, 14, 184, 5, 99, 172, 149]);
-                jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as Logger);
-            });
-
-            afterEach(() => {
-                jest.clearAllMocks();
-            });
-
-            it("should succeed with a JWT that has signing key in config but not in JWK", async () => {
-                delete signingPublicJwk.alg;
-                jwtVerifierConfig.jwtSigningAlgorithm = "ECDSA";
-                jwtVerifyOptions.algorithms = ["ECDSA"];
-
-                const encodedJwt = Buffer.from("example.encoded.jwt");
-                jest.spyOn(global.Buffer, "from").mockReturnValueOnce(encodedJwt);
-                jest.spyOn(global.JSON, "parse").mockReturnValueOnce(signingPublicJwk);
-
-                const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
-                const jwtVerifyMock = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
-                const mandatoryClaims = new Set(["iss", "sub"]);
-                const expectedClaimValues = new Map([
-                    ["iss", "some-issuer"],
-                    ["sub", "some-subject"],
-                    ["aud", "some-audience"],
-                ]);
-                const jwtPayload = {
-                    iss: "some-issuer",
-                    sub: "some-subject",
-                    aud: "some-audience",
+                jwtVerifierConfig = {
+                    publicSigningJwk: "publicSigningJwk",
+                    jwtSigningAlgorithm: "ES256",
                 };
-                importJWKMock.mockResolvedValueOnce(publicKey);
-                jwtVerifyMock.mockResolvedValueOnce({
-                    payload: jwtPayload,
-                    protectedHeader: {} as JWTHeaderParameters,
-                } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
-
-                const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
-
-                expect(payload).toEqual({
-                    iss: "some-issuer",
-                    sub: "some-subject",
-                    aud: "some-audience",
-                });
-                expect(Buffer.from).toHaveBeenCalledWith("publicSigningJwk", "base64");
-                expect(JSON.parse).toHaveBeenCalledWith("example.encoded.jwt");
-                expect(importJWKMock).toBeCalledWith(signingPublicJwk, jwtVerifierConfig.jwtSigningAlgorithm);
-                expect(jwtVerifyMock).toBeCalledWith(encodedJwt, publicKey, jwtVerifyOptions);
-                expect(logger.error).not.toHaveBeenCalled();
-            });
-
-            it("should succeed with a JWT that has signing key and mandatory claims", async () => {
-                const encodedJwt = Buffer.from("example.encoded.jwt");
-                jest.spyOn(global.Buffer, "from").mockReturnValueOnce(encodedJwt);
-                jest.spyOn(global.JSON, "parse").mockReturnValueOnce(signingPublicJwk);
-
-                const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
-                const jwtVerifyMock = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
-                const mandatoryClaims = new Set(["iss", "sub"]);
-                const expectedClaimValues = new Map([
-                    ["iss", "some-issuer"],
-                    ["sub", "some-subject"],
-                    ["aud", "some-audience"],
-                ]);
-                const jwtPayload = {
-                    iss: "some-issuer",
-                    sub: "some-subject",
-                    aud: "some-audience",
-                };
-                importJWKMock.mockResolvedValueOnce(publicKey);
-                jwtVerifyMock.mockResolvedValueOnce({
-                    payload: jwtPayload,
-                    protectedHeader: {} as JWTHeaderParameters,
-                } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
-
-                const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
-
-                expect(payload).toEqual({
-                    iss: "some-issuer",
-                    sub: "some-subject",
-                    aud: "some-audience",
-                });
-                expect(Buffer.from).toHaveBeenCalledWith("publicSigningJwk", "base64");
-                expect(JSON.parse).toHaveBeenCalledWith("example.encoded.jwt");
-                expect(importJWKMock).toBeCalledWith(signingPublicJwk, signingPublicJwk.alg);
-                expect(jwtVerifyMock).toBeCalledWith(encodedJwt, publicKey, jwtVerifyOptions);
-                expect(logger.error).not.toHaveBeenCalled();
-            });
-            it("should return null when mandatory claim is missing in JWT payload", async () => {
-                const encodedJwt = Buffer.from("example.encoded.jwt");
-                jest.spyOn(global.Buffer, "from").mockReturnValueOnce(encodedJwt);
-                jest.spyOn(global.JSON, "parse").mockReturnValueOnce(signingPublicJwk);
-
-                const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
-                const jwtVerifyMock = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
-
-                const mandatoryClaims = new Set(["iss", "sub"]);
-                const expectedClaimValues = new Map([
-                    ["iss", "some-issuer"],
-                    ["sub", "some-subject"],
-                    ["aud", "some-audience"],
-                ]);
-                const jwtPayload = {
-                    iss: "some-issuer",
-                    aud: "some-audience",
-                };
-
-                importJWKMock.mockResolvedValueOnce(publicKey);
-                jwtVerifyMock.mockResolvedValueOnce({
-                    payload: jwtPayload,
-                    protectedHeader: {} as JWTHeaderParameters,
-                } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
-
-                const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
-
-                expect(payload).toBeNull();
-                expect(logger.error).toHaveBeenCalledWith(
-                    "JWT verification failed",
-                    Error("Claims-set missing mandatory claim: sub"),
-                );
-            });
-
-            it("should return null when it fails to import JWK", async () => {
-                jest.spyOn(jose, "importJWK").mockRejectedValue(new Error("Failed to import JWK"));
-                jest.spyOn(global.JSON, "parse").mockReturnValueOnce("some-parsed-value");
-                const encodedJwt = Buffer.from("expect.jwt.value");
-
-                const payload = await jwtVerifier.verify(
-                    encodedJwt,
-                    new Set(["iss"]),
-                    new Map([["iss", "some-issuer"]]),
-                );
-
-                expect(payload).toBeNull();
-                expect(logger.error).toHaveBeenCalledWith("JWT verification failed", Error("Failed to import JWK"));
-            });
-
-            it("should return null when it fails to verify JWT", async () => {
-                jest.spyOn(jose, "jwtVerify").mockRejectedValue(new Error("JWT verification failed"));
-                jest.spyOn(global.JSON, "parse").mockReturnValueOnce("some-parsed-value");
-                const encodedJwt = Buffer.from("expect.jwt.value");
-                const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
-                importJWKMock.mockResolvedValueOnce(publicKey);
-
-                const payload = await jwtVerifier.verify(
-                    encodedJwt,
-                    new Set(["iss"]),
-                    new Map([["iss", "some-issuer"]]),
-                );
-
-                expect(payload).toBeNull();
-                expect(logger.error).toHaveBeenCalledWith("JWT verification failed", Error("JWT verification failed"));
-            });
-            it("should return null and log an error if JWT verification fails due to invalid public signing jwk", async () => {
-                const encodedJwt = Buffer.from("exampleEncodedJwt");
-
-                const payload = await jwtVerifier.verify(
-                    encodedJwt,
-                    new Set(["iss"]),
-                    new Map([["iss", "some-issuer"]]),
-                );
-
-                expect(payload).toBeNull();
-                expect(logger.error).toHaveBeenCalledWith(
-                    "JWT verification failed",
-                    expect.objectContaining({ message: expect.stringMatching(/Unexpected token '?�'?/) }),
-                );
-            });
-            it("should return null and log an error if one of JWT verification Options is invalid", async () => {
-                const jwtVerifyOptions = {
-                    algorithms: ["HS256"],
+                jwtVerifyOptions = {
+                    algorithms: ["ES256"],
                     audience: "some-audience",
                     issuer: "some-issuer",
                     subject: "some-subject",
+                } as unknown as JwkKeyExtendedExportOptions;
+            });
+
+            describe("JWKS Endpoint", () => {
+                const MOCK_JWKS = {
+                    keys: [
+                        { kty: "RSA", e: "AQAB", use: "enc", alg: "RS256", n: "dummy-n", kid: "dummy-kid" },
+                        {
+                            kty: "EC",
+                            use: "sig",
+                            crv: "P-256",
+                            x: "dummy-x",
+                            y: "dummy-y",
+                            alg: "ES256",
+                            kid: "dummy-kid",
+                        },
+                    ],
                 };
-
+                const MOCK_JWT = {
+                    iss: "some-issuer",
+                    sub: "some-subject",
+                    aud: "some-audience",
+                };
                 const encodedJwt = Buffer.from("example.encoded.jwt");
-                jest.spyOn(global.Buffer, "from").mockReturnValueOnce(encodedJwt);
-                jest.spyOn(global.JSON, "parse").mockReturnValueOnce(signingPublicJwk);
-
-                const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
-                const jwtVerifyMock = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
-
                 const mandatoryClaims = new Set(["iss", "sub"]);
                 const expectedClaimValues = new Map([
                     ["iss", "some-issuer"],
                     ["sub", "some-subject"],
                     ["aud", "some-audience"],
                 ]);
-                importJWKMock.mockResolvedValueOnce(publicKey);
-
-                const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
-
-                expect(payload).toBeNull;
-                expect(Buffer.from).toHaveBeenCalledWith("publicSigningJwk", "base64");
-                expect(JSON.parse).toHaveBeenCalledWith("example.encoded.jwt");
-                expect(importJWKMock).toBeCalledWith(signingPublicJwk, signingPublicJwk.alg);
-                expect(jwtVerifyMock).not.toBeCalledWith(encodedJwt, publicKey, jwtVerifyOptions);
-                expect(logger.error).toHaveBeenCalledWith("JWT verification failed", Error("JWT verification failed"));
-            });
-            it("should return null when mandatory claims is empty", async () => {
-                const encodedJwt = Buffer.from("example.encoded.jwt");
-                jest.spyOn(global.Buffer, "from").mockReturnValueOnce(encodedJwt);
-                jest.spyOn(global.JSON, "parse").mockReturnValueOnce(signingPublicJwk);
-
-                const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
                 const jwtVerifyMock = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+                let verifyWithJwksParamSpy: jest.SpyInstance;
 
-                const mandatoryClaims = new Set([]);
-                const expectedClaimValues = new Map([
-                    ["iss", "some-issuer"],
-                    ["sub", "some-subject"],
-                    ["aud", "some-audience"],
-                ]);
-                const jwtPayload = {
-                    iss: "some-issuer",
-                    sub: "some-subject",
-                    aud: "some-audience",
-                };
+                beforeEach(() => {
+                    global.fetch = jest.fn();
+                    process.env.ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK = "true";
+                    process.env.PUBLIC_JWKS_ENDPOINT = "http://localhost";
+                    jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as Logger);
+                    jwtVerifyMock.mockResolvedValue({
+                        payload: MOCK_JWT,
+                        protectedHeader: {} as JWTHeaderParameters,
+                    } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
+                    // @ts-expect-error: Private function
+                    verifyWithJwksParamSpy = jest.spyOn(jwtVerifier, "verifyWithJwksParam");
+                });
 
-                importJWKMock.mockResolvedValueOnce(publicKey);
-                jwtVerifyMock.mockResolvedValueOnce({
-                    payload: jwtPayload,
-                    protectedHeader: {} as JWTHeaderParameters,
-                } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
+                afterEach(() => {
+                    jest.clearAllMocks();
+                    jwtVerifier.clearJWKSCache();
+                });
 
-                const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+                it("should successfully verify JWT using JWKS endpoint", async () => {
+                    (global.fetch as jest.Mock).mockResolvedValueOnce({
+                        headers: {
+                            get: jest.fn().mockReturnValueOnce("max-age=300"),
+                        },
+                        json: jest.fn().mockResolvedValueOnce(MOCK_JWKS),
+                        status: 200,
+                        ok: true,
+                    });
 
-                expect(payload).toBeNull;
-                expect(Buffer.from).toHaveBeenCalledWith("publicSigningJwk", "base64");
-                expect(JSON.parse).toHaveBeenCalledWith("example.encoded.jwt");
-                expect(importJWKMock).toBeCalledWith(signingPublicJwk, signingPublicJwk.alg);
-                expect(jwtVerifyMock).toBeCalledWith(encodedJwt, publicKey, jwtVerifyOptions);
-                expect(logger.error).toHaveBeenCalledWith(
-                    "JWT verification failed",
-                    Error("No mandatory claims provided"),
-                );
+                    const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+
+                    expect(payload).toEqual(MOCK_JWT);
+                    expect(verifyWithJwksParamSpy).not.toHaveBeenCalled();
+                    expect(logger.info).toHaveBeenCalledWith("Sucessfully verified JWT using Public JWKS Endpoint");
+                });
+
+                it("should successfully uses the cached JWKS when populated", async () => {
+                    (global.fetch as jest.Mock).mockResolvedValue({
+                        headers: {
+                            get: jest.fn().mockReturnValue("max-age=300"),
+                        },
+                        json: jest.fn().mockResolvedValue(MOCK_JWKS),
+                        status: 200,
+                        ok: true,
+                    });
+
+                    const payloadOne = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+                    expect(payloadOne).toEqual(MOCK_JWT);
+                    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+                    const payloadTwo = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+                    expect(payloadTwo).toEqual(MOCK_JWT);
+                    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+                    jwtVerifier.clearJWKSCache();
+                    const payloadThree = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+                    expect(payloadThree).toEqual(MOCK_JWT);
+                    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+                    expect(verifyWithJwksParamSpy).toHaveBeenCalledTimes(0);
+                });
+
+                it("should successfully verify JWT using JWKS endpoint when Cache-Control regex does not match", async () => {
+                    (global.fetch as jest.Mock).mockResolvedValueOnce({
+                        headers: {
+                            get: jest.fn().mockReturnValueOnce("no-cache"),
+                        },
+                        json: jest.fn().mockResolvedValueOnce(MOCK_JWKS),
+                        status: 200,
+                        ok: true,
+                    });
+
+                    const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+
+                    expect(payload).toEqual(MOCK_JWT);
+                    expect(verifyWithJwksParamSpy).toHaveBeenCalledTimes(0);
+                });
+
+                it("should successfully verify JWT using JWKS endpoint when Cache-Control header is not present", async () => {
+                    (global.fetch as jest.Mock).mockResolvedValueOnce({
+                        headers: {
+                            get: jest.fn().mockReturnValueOnce(null),
+                        },
+                        json: jest.fn().mockResolvedValueOnce(MOCK_JWKS),
+                        status: 200,
+                        ok: true,
+                    });
+
+                    const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+
+                    expect(payload).toEqual(MOCK_JWT);
+                    expect(verifyWithJwksParamSpy).toHaveBeenCalledTimes(0);
+                });
+
+                describe("JWKS Endpoint fail and fallback", () => {
+                    it("should use fallback method when PUBLIC_JWKS_ENDPOINT is not set", async () => {
+                        process.env.PUBLIC_JWKS_ENDPOINT = "";
+
+                        jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as Logger);
+                        // @ts-expect-error: Private function
+                        const fallbackSpy = jest.spyOn(jwtVerifier, "verifyWithJwksParam").mockImplementation(() => {
+                            return {
+                                iss: "some-issuer",
+                                sub: "some-subject",
+                                aud: "some-audience",
+                            };
+                        });
+                        const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+
+                        expect(fallbackSpy).toBeCalledTimes(1);
+                        expect(fallbackSpy).toHaveBeenCalledWith(encodedJwt, mandatoryClaims, jwtVerifyOptions);
+                        expect(payload).toEqual({
+                            iss: "some-issuer",
+                            sub: "some-subject",
+                            aud: "some-audience",
+                        });
+                    });
+
+                    it("should use fallback method when PUBLIC_JWKS_ENDPOINT is not a valid url", async () => {
+                        process.env.PUBLIC_JWKS_ENDPOINT = "localhost";
+
+                        jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as Logger);
+                        // @ts-expect-error: Private function
+                        const fallbackSpy = jest.spyOn(jwtVerifier, "verifyWithJwksParam").mockImplementation(() => {
+                            return {
+                                iss: "some-issuer",
+                                sub: "some-subject",
+                                aud: "some-audience",
+                            };
+                        });
+                        const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+
+                        expect(fallbackSpy).toBeCalledTimes(1);
+                        expect(fallbackSpy).toHaveBeenCalledWith(encodedJwt, mandatoryClaims, jwtVerifyOptions);
+                        expect(payload).toEqual({
+                            iss: "some-issuer",
+                            sub: "some-subject",
+                            aud: "some-audience",
+                        });
+                    });
+
+                    it("should use fallback method if JWKS endpoint does not return 200", async () => {
+                        (global.fetch as jest.Mock).mockResolvedValueOnce({
+                            status: 400,
+                            ok: false,
+                        });
+
+                        jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as Logger);
+                        // @ts-expect-error: Private function
+                        const fallbackSpy = jest.spyOn(jwtVerifier, "verifyWithJwksParam").mockImplementation(() => {
+                            return {
+                                iss: "some-issuer",
+                                sub: "some-subject",
+                                aud: "some-audience",
+                            };
+                        });
+                        const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+
+                        expect(fallbackSpy).toBeCalledTimes(1);
+                        expect(fallbackSpy).toHaveBeenCalledWith(encodedJwt, mandatoryClaims, jwtVerifyOptions);
+                        expect(payload).toEqual({
+                            iss: "some-issuer",
+                            sub: "some-subject",
+                            aud: "some-audience",
+                        });
+                    });
+
+                    it("should fail if JWT does not have mandatory claims", async () => {
+                        (global.fetch as jest.Mock).mockResolvedValueOnce({
+                            headers: {
+                                get: jest.fn().mockReturnValueOnce("max-age=300"),
+                            },
+                            json: jest.fn().mockResolvedValueOnce(MOCK_JWKS),
+                            status: 200,
+                            ok: true,
+                        });
+
+                        jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as Logger);
+                        // @ts-expect-error: Private function
+                        const fallbackSpy = jest.spyOn(jwtVerifier, "verifyWithJwksParam").mockImplementation(() => {
+                            return null;
+                        });
+                        const mandatoryClaimsFail = new Set(["iss", "sub", "abc"]);
+                        const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaimsFail, expectedClaimValues);
+
+                        expect(fallbackSpy).toBeCalledTimes(1);
+                        expect(fallbackSpy).toHaveBeenCalledWith(encodedJwt, mandatoryClaimsFail, jwtVerifyOptions);
+                        expect(payload).toEqual(null);
+                    });
+                });
             });
-            it("should return null when mandatory claims is undefined", async () => {
-                const encodedJwt = Buffer.from("example.encoded.jwt");
-                jest.spyOn(global.Buffer, "from").mockReturnValueOnce(encodedJwt);
-                jest.spyOn(global.JSON, "parse").mockReturnValueOnce(signingPublicJwk);
 
-                const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
-                const jwtVerifyMock = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+            describe("JWKS Param", () => {
+                let publicKey: Uint8Array;
+                let signingPublicJwk: jose.JWK;
 
-                const expectedClaimValues = new Map([
-                    ["iss", "some-issuer"],
-                    ["sub", "some-subject"],
-                    ["aud", "some-audience"],
-                ]);
-                const jwtPayload = {
-                    iss: "some-issuer",
-                    sub: "some-subject",
-                    aud: "some-audience",
-                };
+                beforeEach(() => {
+                    logger = {
+                        error: jest.fn(),
+                        info: jest.fn(),
+                    } as unknown as Logger;
+                    publicKey = new Uint8Array([3, 101, 120, 26, 14, 184, 5, 99, 172, 149]);
+                    process.env.ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK = "false";
+                    process.env.PUBLIC_JWKS_ENDPOINT = undefined;
+                    jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as Logger);
+                    signingPublicJwk = {
+                        alg: "ES256",
+                        kty: "kty",
+                        use: "use",
+                        x: "x",
+                        y: "y",
+                    };
+                });
 
-                importJWKMock.mockResolvedValueOnce(publicKey);
-                jwtVerifyMock.mockResolvedValueOnce({
-                    payload: jwtPayload,
-                    protectedHeader: {} as JWTHeaderParameters,
-                } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
+                afterEach(() => {
+                    jest.clearAllMocks();
+                });
 
-                const payload = await jwtVerifier.verify(
-                    encodedJwt,
-                    undefined as unknown as Set<string>,
-                    expectedClaimValues,
-                );
+                it("should succeed with a JWT that has signing key in config but not in JWK", async () => {
+                    delete signingPublicJwk.alg;
+                    jwtVerifierConfig.jwtSigningAlgorithm = "ECDSA";
+                    jwtVerifyOptions.algorithms = ["ECDSA"];
 
-                expect(payload).toBeNull;
-                expect(Buffer.from).toHaveBeenCalledWith("publicSigningJwk", "base64");
-                expect(JSON.parse).toHaveBeenCalledWith("example.encoded.jwt");
-                expect(importJWKMock).toBeCalledWith(signingPublicJwk, signingPublicJwk.alg);
-                expect(jwtVerifyMock).toBeCalledWith(encodedJwt, publicKey, jwtVerifyOptions);
-                expect(logger.error).toHaveBeenCalledWith(
-                    "JWT verification failed",
-                    Error("No mandatory claims provided"),
-                );
+                    const encodedJwt = Buffer.from("example.encoded.jwt");
+                    jest.spyOn(global.Buffer, "from").mockReturnValueOnce(encodedJwt);
+                    jest.spyOn(global.JSON, "parse").mockReturnValueOnce(signingPublicJwk);
+
+                    const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
+                    const jwtVerifyMock = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+                    const mandatoryClaims = new Set(["iss", "sub"]);
+                    const expectedClaimValues = new Map([
+                        ["iss", "some-issuer"],
+                        ["sub", "some-subject"],
+                        ["aud", "some-audience"],
+                    ]);
+                    const jwtPayload = {
+                        iss: "some-issuer",
+                        sub: "some-subject",
+                        aud: "some-audience",
+                    };
+                    importJWKMock.mockResolvedValueOnce(publicKey);
+                    jwtVerifyMock.mockResolvedValueOnce({
+                        payload: jwtPayload,
+                        protectedHeader: {} as JWTHeaderParameters,
+                    } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
+
+                    const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+
+                    expect(payload).toEqual({
+                        iss: "some-issuer",
+                        sub: "some-subject",
+                        aud: "some-audience",
+                    });
+                    expect(Buffer.from).toHaveBeenCalledWith("publicSigningJwk", "base64");
+                    expect(JSON.parse).toHaveBeenCalledWith("example.encoded.jwt");
+                    expect(importJWKMock).toBeCalledWith(signingPublicJwk, jwtVerifierConfig.jwtSigningAlgorithm);
+                    expect(jwtVerifyMock).toBeCalledWith(encodedJwt, publicKey, jwtVerifyOptions);
+                    expect(logger.error).not.toHaveBeenCalled();
+                });
+
+                it("should succeed with a JWT that has signing key and mandatory claims", async () => {
+                    const encodedJwt = Buffer.from("example.encoded.jwt");
+                    jest.spyOn(global.Buffer, "from").mockReturnValueOnce(encodedJwt);
+                    jest.spyOn(global.JSON, "parse").mockReturnValueOnce(signingPublicJwk);
+
+                    const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
+                    const jwtVerifyMock = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+                    const mandatoryClaims = new Set(["iss", "sub"]);
+                    const expectedClaimValues = new Map([
+                        ["iss", "some-issuer"],
+                        ["sub", "some-subject"],
+                        ["aud", "some-audience"],
+                    ]);
+                    const jwtPayload = {
+                        iss: "some-issuer",
+                        sub: "some-subject",
+                        aud: "some-audience",
+                    };
+                    importJWKMock.mockResolvedValueOnce(publicKey);
+                    jwtVerifyMock.mockResolvedValueOnce({
+                        payload: jwtPayload,
+                        protectedHeader: {} as JWTHeaderParameters,
+                    } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
+
+                    const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+
+                    expect(payload).toEqual({
+                        iss: "some-issuer",
+                        sub: "some-subject",
+                        aud: "some-audience",
+                    });
+                    expect(Buffer.from).toHaveBeenCalledWith("publicSigningJwk", "base64");
+                    expect(JSON.parse).toHaveBeenCalledWith("example.encoded.jwt");
+                    expect(importJWKMock).toBeCalledWith(signingPublicJwk, signingPublicJwk.alg);
+                    expect(jwtVerifyMock).toBeCalledWith(encodedJwt, publicKey, jwtVerifyOptions);
+                    expect(logger.error).not.toHaveBeenCalled();
+                });
+                it("should return null when mandatory claim is missing in JWT payload", async () => {
+                    const encodedJwt = Buffer.from("example.encoded.jwt");
+                    jest.spyOn(global.Buffer, "from").mockReturnValueOnce(encodedJwt);
+                    jest.spyOn(global.JSON, "parse").mockReturnValueOnce(signingPublicJwk);
+
+                    const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
+                    const jwtVerifyMock = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+
+                    const mandatoryClaims = new Set(["iss", "sub"]);
+                    const expectedClaimValues = new Map([
+                        ["iss", "some-issuer"],
+                        ["sub", "some-subject"],
+                        ["aud", "some-audience"],
+                    ]);
+                    const jwtPayload = {
+                        iss: "some-issuer",
+                        aud: "some-audience",
+                    };
+
+                    importJWKMock.mockResolvedValueOnce(publicKey);
+                    jwtVerifyMock.mockResolvedValueOnce({
+                        payload: jwtPayload,
+                        protectedHeader: {} as JWTHeaderParameters,
+                    } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
+
+                    const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+
+                    expect(payload).toBeNull();
+                    expect(logger.error).toHaveBeenCalledWith(
+                        "JWT verification failed with JWKS parameter",
+                        Error("Claims-set missing mandatory claim: sub"),
+                    );
+                });
+
+                it("should return null when it fails to import JWK", async () => {
+                    jest.spyOn(jose, "importJWK").mockRejectedValue(new Error("Failed to import JWK"));
+                    jest.spyOn(global.JSON, "parse").mockReturnValueOnce("some-parsed-value");
+                    const encodedJwt = Buffer.from("expect.jwt.value");
+
+                    const payload = await jwtVerifier.verify(
+                        encodedJwt,
+                        new Set(["iss"]),
+                        new Map([["iss", "some-issuer"]]),
+                    );
+
+                    expect(payload).toBeNull();
+                    expect(logger.error).toHaveBeenCalledWith(
+                        "JWT verification failed with JWKS parameter",
+                        Error("Failed to import JWK"),
+                    );
+                });
+
+                it("should return null when it fails to verify JWT", async () => {
+                    jest.spyOn(jose, "jwtVerify").mockRejectedValue(
+                        new Error("JWT verification failed with JWKS parameter"),
+                    );
+                    jest.spyOn(global.JSON, "parse").mockReturnValueOnce("some-parsed-value");
+                    const encodedJwt = Buffer.from("expect.jwt.value");
+                    const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
+                    importJWKMock.mockResolvedValueOnce(publicKey);
+
+                    const payload = await jwtVerifier.verify(
+                        encodedJwt,
+                        new Set(["iss"]),
+                        new Map([["iss", "some-issuer"]]),
+                    );
+
+                    expect(payload).toBeNull();
+                    expect(logger.error).toHaveBeenCalledWith(
+                        "JWT verification failed with JWKS parameter",
+                        Error("JWT verification failed with JWKS parameter"),
+                    );
+                });
+                it("should return null and log an error if JWT verification fails due to invalid public signing jwk", async () => {
+                    const encodedJwt = Buffer.from("exampleEncodedJwt");
+
+                    const payload = await jwtVerifier.verify(
+                        encodedJwt,
+                        new Set(["iss"]),
+                        new Map([["iss", "some-issuer"]]),
+                    );
+
+                    expect(payload).toBeNull();
+                    expect(logger.error).toHaveBeenCalledWith(
+                        "JWT verification failed with JWKS parameter",
+                        expect.objectContaining({ message: expect.stringMatching(/Unexpected token '?�'?/) }),
+                    );
+                });
+                it("should return null and log an error if one of JWT verification Options is invalid", async () => {
+                    const jwtVerifyOptions = {
+                        algorithms: ["HS256"],
+                        audience: "some-audience",
+                        issuer: "some-issuer",
+                        subject: "some-subject",
+                    };
+
+                    const encodedJwt = Buffer.from("example.encoded.jwt");
+                    jest.spyOn(global.Buffer, "from").mockReturnValueOnce(encodedJwt);
+                    jest.spyOn(global.JSON, "parse").mockReturnValueOnce(signingPublicJwk);
+
+                    const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
+                    const jwtVerifyMock = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+
+                    const mandatoryClaims = new Set(["iss", "sub"]);
+                    const expectedClaimValues = new Map([
+                        ["iss", "some-issuer"],
+                        ["sub", "some-subject"],
+                        ["aud", "some-audience"],
+                    ]);
+                    importJWKMock.mockResolvedValueOnce(publicKey);
+
+                    const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+
+                    expect(payload).toBeNull;
+                    expect(Buffer.from).toHaveBeenCalledWith("publicSigningJwk", "base64");
+                    expect(JSON.parse).toHaveBeenCalledWith("example.encoded.jwt");
+                    expect(importJWKMock).toBeCalledWith(signingPublicJwk, signingPublicJwk.alg);
+                    expect(jwtVerifyMock).not.toBeCalledWith(encodedJwt, publicKey, jwtVerifyOptions);
+                    expect(logger.error).toHaveBeenCalledWith(
+                        "JWT verification failed with JWKS parameter",
+                        Error("JWT verification failed with JWKS parameter"),
+                    );
+                });
+                it("should return null when mandatory claims is empty", async () => {
+                    const encodedJwt = Buffer.from("example.encoded.jwt");
+                    jest.spyOn(global.Buffer, "from").mockReturnValueOnce(encodedJwt);
+                    jest.spyOn(global.JSON, "parse").mockReturnValueOnce(signingPublicJwk);
+
+                    const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
+                    const jwtVerifyMock = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+
+                    const mandatoryClaims = new Set([]);
+                    const expectedClaimValues = new Map([
+                        ["iss", "some-issuer"],
+                        ["sub", "some-subject"],
+                        ["aud", "some-audience"],
+                    ]);
+                    const jwtPayload = {
+                        iss: "some-issuer",
+                        sub: "some-subject",
+                        aud: "some-audience",
+                    };
+
+                    importJWKMock.mockResolvedValueOnce(publicKey);
+                    jwtVerifyMock.mockResolvedValueOnce({
+                        payload: jwtPayload,
+                        protectedHeader: {} as JWTHeaderParameters,
+                    } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
+
+                    const payload = await jwtVerifier.verify(encodedJwt, mandatoryClaims, expectedClaimValues);
+
+                    expect(payload).toBeNull;
+                    expect(Buffer.from).toHaveBeenCalledWith("publicSigningJwk", "base64");
+                    expect(JSON.parse).toHaveBeenCalledWith("example.encoded.jwt");
+                    expect(importJWKMock).toBeCalledWith(signingPublicJwk, signingPublicJwk.alg);
+                    expect(jwtVerifyMock).toBeCalledWith(encodedJwt, publicKey, jwtVerifyOptions);
+                    expect(logger.error).toHaveBeenCalledWith(
+                        "JWT verification failed with JWKS parameter",
+                        Error("No mandatory claims provided"),
+                    );
+                });
+                it("should return null when mandatory claims is undefined", async () => {
+                    const encodedJwt = Buffer.from("example.encoded.jwt");
+                    jest.spyOn(global.Buffer, "from").mockReturnValueOnce(encodedJwt);
+                    jest.spyOn(global.JSON, "parse").mockReturnValueOnce(signingPublicJwk);
+
+                    const importJWKMock = importJWK as jest.MockedFunction<typeof importJWK>;
+                    const jwtVerifyMock = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+
+                    const expectedClaimValues = new Map([
+                        ["iss", "some-issuer"],
+                        ["sub", "some-subject"],
+                        ["aud", "some-audience"],
+                    ]);
+                    const jwtPayload = {
+                        iss: "some-issuer",
+                        sub: "some-subject",
+                        aud: "some-audience",
+                    };
+
+                    importJWKMock.mockResolvedValueOnce(publicKey);
+                    jwtVerifyMock.mockResolvedValueOnce({
+                        payload: jwtPayload,
+                        protectedHeader: {} as JWTHeaderParameters,
+                    } as unknown as Promise<jose.JWTVerifyResult & jose.ResolvedKey>);
+
+                    const payload = await jwtVerifier.verify(
+                        encodedJwt,
+                        undefined as unknown as Set<string>,
+                        expectedClaimValues,
+                    );
+
+                    expect(payload).toBeNull;
+                    expect(Buffer.from).toHaveBeenCalledWith("publicSigningJwk", "base64");
+                    expect(JSON.parse).toHaveBeenCalledWith("example.encoded.jwt");
+                    expect(importJWKMock).toBeCalledWith(signingPublicJwk, signingPublicJwk.alg);
+                    expect(jwtVerifyMock).toBeCalledWith(encodedJwt, publicKey, jwtVerifyOptions);
+                    expect(logger.error).toHaveBeenCalledWith(
+                        "JWT verification failed with JWKS parameter",
+                        Error("No mandatory claims provided"),
+                    );
+                });
             });
         });
     });


### PR DESCRIPTION
## Proposed changes

### What changed

JWT verifying will now attempt to retrieve the JWKS from a endpoint. This is configured through the `ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK` & `PUBLIC_JWKS_ENDPOINT` environment variables.

Otherwise, it will continue to use the SSM param. Fallback logic is also implemented, so if the JWKS endpoint fails for any reason it will attempt to use the parameters.

The JWKS endpoint response will be cached for as long as returned int the Cache-Control header returned in the JWKS endpoint response.

It has only been enabled for Experian KBV dev.

*Note for Reviewing: I have not changed the `JWKS Param` unit tests, I've just wrapped them in a new describe. GitHub seems to have picked them all up as changed code.

### Why did it change

When the Session lambda receives a JWT from core it needs to verify the signature using the key document from their JWKS endpoint.

### Issue tracking

- [OJ-3077](https://govukverify.atlassian.net/browse/OJ-3077)


[OJ-3077]: https://govukverify.atlassian.net/browse/OJ-3077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ