### PR TITLE
OJ-3077: Enable using JWKS endpoint in kbv build and staging

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -184,8 +184,8 @@ Mappings:
       production: false
     di-ipv-cri-kbv-api:
       dev: true
-      build: false
-      staging: false
+      build: true
+      staging: true
       integration: false
       production: false
     di-ipv-cri-dl-api:


### PR DESCRIPTION
## Proposed changes

### What changed

Enabled using the JWKS endpoint for KBV build and staging. 

### Why did it change

Tested and confirmed working in dev.

### Issue tracking

- [OJ-3077](https://govukverify.atlassian.net/browse/OJ-3077)
