### PR TITLE
OJ-3078: Change the subnet of IsDevPlatformDeploy lambdas to protected

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -78,6 +78,9 @@ Conditions:
   IsDevPlatformDeploy: !Equals
     - !FindInMap [CriVpcMapping, !Ref CriIdentifier, !Ref Environment]
     - "di-devplatform-deploy"
+  IsKeyRotationEnabled: !Equals
+    - !FindInMap [KeyRotationEnabled, !Ref CriIdentifier, !Ref Environment]
+    - true
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -98,10 +101,16 @@ Globals:
         - [!ImportValue cri-vpc-LambdaSecurityGroup]
       SubnetIds: !If
         - IsDevPlatformDeploy
-        - [
+        - !If
+          - IsKeyRotationEnabled
+          - [ 
+            !ImportValue cri-vpc-ProtectedSubnetIdA,
+            !ImportValue cri-vpc-ProtectedSubnetIdB,
+            ]
+          - [ 
             !ImportValue cri-vpc-PrivateSubnetIdA,
             !ImportValue cri-vpc-PrivateSubnetIdB,
-          ]
+            ]
         - !Split [",", !ImportValue cri-vpc-PrivateSubnets]
     PermissionsBoundary: !If
       - UsePermissionsBoundary
@@ -207,7 +216,7 @@ Mappings:
       integration: false
       production: false
     di-ipv-cri-check-hmrc-api:
-      dev: false
+      dev: true
       build: false
       staging: false
       integration: false


### PR DESCRIPTION
## Proposed changes

### What changed

Added an additional `If` to `IsDevPlatformDeploy` for selecting which subnet to use. `IsKeyRotationEnabled` also being true will set the subnet to `protected`.

### Why did it change

Session and Access Token lambdas now need to make a call to core's JWKS endpoint or a stubbed implementation (test-resources). They cannot do this from the private subnet when they are using the newer VPC set up, so need moving to the protected subnet. 

Initially limiting testing with `check-hmrc` dev

### Issue tracking

- [OJ-3078](https://govukverify.atlassian.net/browse/OJ-3078)


[OJ-3078]: https://govukverify.atlassian.net/browse/OJ-3078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ