### PR TITLE
OJ-3080: Add jwt_verification_failed metric to TS session and token

### DIFF
--- a/lambdas/src/common/security/jwt-verifier.ts
+++ b/lambdas/src/common/security/jwt-verifier.ts
@@ -80,7 +80,7 @@ export class JwtVerifier {
     private async fetchAndCacheJWKS(jwksUrl: URL) {
         const jwksResponse = await fetch(jwksUrl);
         if (!jwksResponse.ok) {
-            throw new Error("Error recieved from the JWKS endpoint, status recieved: " + jwksResponse.status);
+            throw new Error("Error received from the JWKS endpoint, status received: " + jwksResponse.status);
         }
 
         cachedJWKS = await jwksResponse.json();

--- a/lambdas/tests/unit/handlers/access-token-handler.test.ts
+++ b/lambdas/tests/unit/handlers/access-token-handler.test.ts
@@ -399,6 +399,7 @@ describe("access-token-handler.ts", () => {
                     Error("JWT signature verification failed"),
                 );
                 expect(metricsSpy).toHaveBeenCalledWith("accesstoken", MetricUnits.Count, 0);
+                expect(metricsSpy).toHaveBeenCalledWith("jwt_verification_failed", MetricUnits.Count, 1);
             });
 
             it("should return http 403 when the session item is invalid", async () => {

--- a/lambdas/tests/unit/handlers/session-handler.test.ts
+++ b/lambdas/tests/unit/handlers/session-handler.test.ts
@@ -207,6 +207,7 @@ describe("SessionLambda", () => {
     });
 
     it("should error on JWE decryption fail", async () => {
+        const metricSpy = jest.spyOn(metrics.prototype, "addMetric");
         jest.spyOn(jweDecrypter.prototype, "decryptJwe").mockRejectedValueOnce(
             new SessionValidationError(
                 "Session Validation Exception",
@@ -222,6 +223,7 @@ describe("SessionLambda", () => {
             "Session Lambda error occurred: 1019: Session Validation Exception - Invalid request: JWT validation/verification failed: failure",
             expect.any(SessionValidationError),
         );
+        expect(metricSpy).toHaveBeenCalledWith("jwt_verification_failed", MetricUnits.Count, 1);
     });
 
     it("should initialise the client config if unavailable", async () => {
@@ -255,6 +257,7 @@ describe("SessionLambda", () => {
     });
 
     it("should error on JWT validation fail", async () => {
+        const metricSpy = jest.spyOn(metrics.prototype, "addMetric");
         jest.spyOn(sessionRequestValidator.prototype, "validateJwt").mockRejectedValueOnce(
             new SessionValidationError(
                 "Session Validation Exception",
@@ -265,6 +268,7 @@ describe("SessionLambda", () => {
         const result = await lambdaHandler(mockEvent, {} as Context);
         expect(result.statusCode).toBe(400);
         expect(result.body).toContain("1019: Session Validation Exception");
+        expect(metricSpy).toHaveBeenCalledWith("jwt_verification_failed", MetricUnits.Count, 1);
     });
 
     it("should save the session details", async () => {


### PR DESCRIPTION
## Proposed changes

### What changed

Added `jwt_verification_failed` metric to TS session and token

Note: There seems to be an issue with metrics not being published when errors are thrown by the `validateJwtMiddleware` and caught by the `errorMiddleware`. I have added `metrics.publishStoredMetrics();` in the errorMiddleware to make sure the new metric is published. This can/should be looked at in more detail if needed in the future.

### Why did it change

Now that we are consuming Cores public signing keys from an endpoint rather than SSM there is more risk that something will go wrong when verifying requests from Core

### Issue tracking

- [OJ-3080](https://govukverify.atlassian.net/browse/OJ-3080)

### Screenshot

![image](https://github.com/user-attachments/assets/eae2f447-e4b3-4730-8630-9279cd3d9913)

[OJ-3080]: https://govukverify.atlassian.net/browse/OJ-3080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ