### PR TITLE
OJ-2969: uses public encryption key from the CRI's ./well-known/jwks.json endpoint

### DIFF
--- a/test-resources/headless-core-stub/lambdas/callback/src/callback-handler.ts
+++ b/test-resources/headless-core-stub/lambdas/callback/src/callback-handler.ts
@@ -9,6 +9,7 @@ import { handleErrorResponse } from "../../../utils/src/errors/error-response";
 import { ClientConfiguration } from "../../../utils/src/services/client-configuration";
 import { base64Decode } from "../../../utils/src/base64";
 import { DEFAULT_CLIENT_ID } from "../../../utils/src/constants";
+import { formatAudience } from "../../../utils/src/audience-formatter";
 
 const logger = new Logger({ serviceName: "CallBackService" });
 const callback = new CallBackService(logger);
@@ -29,7 +30,7 @@ export class CallbackLambdaHandler implements LambdaInterface {
             const audience = statePayload.audience || ssmParameters.audience;
             const redirectUri = statePayload.redirectUri || ssmParameters.redirectUri;
 
-            const audienceApi = this.formatAudience(audience);
+            const audienceApi = formatAudience(audience, logger);
             const tokenEndpoint = `${audienceApi}/token`;
 
             logger.info({ message: "Generating private JWT parameters" });
@@ -81,12 +82,6 @@ export class CallbackLambdaHandler implements LambdaInterface {
 
     private excludeFromRecord = (record: Record<string, string>, excludeKey: string): Record<string, string> => {
         return Object.fromEntries(Object.entries(record).filter(([key]) => key !== excludeKey));
-    };
-    private formatAudience = (audience: string) => {
-        const audienceApi = audience.includes("review-") ? audience.replace("review-", "api.review-") : audience;
-
-        logger.info({ message: "Using Audience", audienceApi });
-        return audienceApi;
     };
 }
 

--- a/test-resources/headless-core-stub/lambdas/start/src/services/signing-service.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/services/signing-service.ts
@@ -1,16 +1,63 @@
 import { GetPublicKeyCommand, KMSClient } from "@aws-sdk/client-kms";
-import { CompactEncrypt, importSPKI, KeyLike } from "jose";
+import { CompactEncrypt, importJWK, importSPKI, JSONWebKeySet, JWK, KeyLike } from "jose";
 import { HeadlessCoreStubError } from "../../../../utils/src/errors/headless-core-stub-error";
+import { formatAudience } from "../../../../utils/src/audience-formatter";
+import { Logger } from "@aws-lambda-powertools/logger";
 
 const kmsClient = new KMSClient({ region: "eu-west-2" });
+export const logger = new Logger();
 
 let cachedPublicKey: KeyLike | undefined;
 
-export const getPublicEncryptionKey = async () => {
+export const getPublicEncryptionKey = async (audience: string) => {
     if (cachedPublicKey) {
         return cachedPublicKey;
     }
 
+    if (process.env.KEY_ROTATION_FEATURE_FLAG_ENABLED === "true") {
+        return await getPublicEncryptionKeyJwksUri(audience);
+    }
+
+    if (!cachedPublicKey) {
+        logger.info({ message: "using KMS to retrieve encryption key" });
+        await getPublicEncryptionKeyFromKms();
+    }
+
+    return cachedPublicKey;
+};
+
+export const encryptSignedJwt = (signedJwt: string, publicEncryptionKey: KeyLike) => {
+    return new CompactEncrypt(new TextEncoder().encode(signedJwt))
+        .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM" })
+        .encrypt(publicEncryptionKey);
+};
+
+async function getPublicEncryptionKeyJwksUri(audience: string) {
+    const audienceApi = formatAudience(audience);
+    const criEncryptionJwksEndpoint = new URL("/.well-known/jwks.json", audienceApi).href;
+
+    logger.info({ message: "Attempting to use CRI hosted public encryption jwks endpoint", criEncryptionJwksEndpoint });
+
+    const data = await fetch(criEncryptionJwksEndpoint, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+    });
+
+    if (!data.ok) {
+        throw new Error(`Failed to fetch JWKS: ${data.status} ${data.statusText}`);
+    }
+
+    const jwks = (await data.json()) as JSONWebKeySet;
+
+    if (!jwks.keys || !Array.isArray(jwks.keys) || jwks.keys.length === 0) {
+        throw new Error(`Invalid or empty JWKS response from ${criEncryptionJwksEndpoint}`);
+    }
+    logger.info({ message: "Successfully retrieved public encryption jwks endpoint", ...jwks });
+
+    cachedPublicKey = (await importJWK(jwks.keys.find((k) => k.use === "enc") as JWK, "RSA-OAEP-256")) as KeyLike;
+}
+
+async function getPublicEncryptionKeyFromKms() {
     const decryptionKeyId = process.env.DECRYPTION_KEY_ID;
     if (!decryptionKeyId) {
         throw new HeadlessCoreStubError("Decryption key ID not present", 500);
@@ -28,11 +75,4 @@ export const getPublicEncryptionKey = async () => {
     const publicKeyPem = `${header}\n${value}\n${footer}`;
 
     cachedPublicKey = await importSPKI(publicKeyPem, "RS256");
-    return cachedPublicKey;
-};
-
-export const encryptSignedJwt = (signedJwt: string, publicEncryptionKey: KeyLike) => {
-    return new CompactEncrypt(new TextEncoder().encode(signedJwt))
-        .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM" })
-        .encrypt(publicEncryptionKey);
-};
+}

--- a/test-resources/headless-core-stub/lambdas/start/src/start-handler.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/start-handler.ts
@@ -34,7 +34,7 @@ export class StartLambdaHandler implements LambdaInterface {
             };
             const signedJwt = await signJwt(jwtClaimsSet as JWTPayload, signingKey, jwtHeader);
 
-            const publicEncryptionKey: KeyLike = await getPublicEncryptionKey();
+            const publicEncryptionKey = (await getPublicEncryptionKey(jwtClaimsSet.aud)) as KeyLike;
 
             const encryptedSignedJwt = await encryptSignedJwt(signedJwt, publicEncryptionKey);
 

--- a/test-resources/headless-core-stub/lambdas/start/tests/services/signing-service.test.ts
+++ b/test-resources/headless-core-stub/lambdas/start/tests/services/signing-service.test.ts
@@ -5,9 +5,11 @@ import { generateKeyPairSync } from "crypto";
 import { HeadlessCoreStubError } from "../../../../utils/src/errors/headless-core-stub-error";
 import { encryptSignedJwt, getPublicEncryptionKey } from "../../src/services/signing-service";
 import { TestData } from "../../../../utils/tests/test-data";
+import { KeyLike } from "jose";
 
-describe("crypto-service", () => {
-    describe("getPublicEncryptionKey", () => {
+describe("signing-service", () => {
+    const audience = "https://test-audience.com";
+    describe("getPublicEncryptionKey - kms", () => {
         const mockKMSClient = mockClient(KMSClient);
 
         afterEach(() => {
@@ -16,14 +18,14 @@ describe("crypto-service", () => {
         });
 
         it("throws error with 500 if decryption key env variable not set", async () => {
-            await expect(getPublicEncryptionKey()).rejects.toThrow(
+            await expect(getPublicEncryptionKey(audience)).rejects.toThrow(
                 new HeadlessCoreStubError("Decryption key ID not present", 500),
             );
         });
 
         it("throws error with 500 if kms key not retrieved", async () => {
             process.env.DECRYPTION_KEY_ID = "abc123";
-            await expect(getPublicEncryptionKey()).rejects.toThrow(
+            await expect(getPublicEncryptionKey(audience)).rejects.toThrow(
                 new HeadlessCoreStubError("Unable to retrieve public encryption key", 500),
             );
         });
@@ -47,8 +49,65 @@ describe("crypto-service", () => {
             const mockKMSClient = mockClient(KMSClient);
             mockKMSClient.on(GetPublicKeyCommand, { KeyId: "abc123" }).resolvesOnce({ PublicKey: keyBuffer });
 
-            const result = await getPublicEncryptionKey();
-            expect(result.type).toEqual("public");
+            const result = await getPublicEncryptionKey(audience);
+            expect(result?.type).toEqual("public");
+        });
+    });
+
+    describe("getPublicEncryptionKey - jwks uri", () => {
+        let originalFetch: typeof global.fetch;
+
+        beforeEach(() => {
+            originalFetch = global.fetch;
+        });
+
+        afterEach(() => {
+            global.fetch = originalFetch;
+            clearCaches();
+            delete process.env.DECRYPTION_KEY_ID;
+        });
+
+        it("retrieves public encryption key from JWKS endpoint", async () => {
+            const mockJwks = {
+                keys: [{ kty: "RSA", e: "AQAB", use: "enc", alg: "RS256", n: "dummy-n", kid: "dummy-kid" }],
+            };
+            process.env.KEY_ROTATION_FEATURE_FLAG_ENABLED == "true";
+
+            global.fetch = jest.fn().mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(mockJwks),
+            });
+
+            const result = await getPublicEncryptionKey("https://test-audience.co.uk");
+
+            expect(result).toBeDefined();
+            expect(result?.type).toBe("public");
+        });
+
+        it("falls back to KMS if JWKS fetch fails", async () => {
+            process.env.KEY_ROTATION_FEATURE_FLAG_ENABLED == "false";
+
+            const { publicKey } = generateKeyPairSync("rsa", {
+                modulusLength: 2048,
+                publicKeyEncoding: {
+                    type: "spki",
+                    format: "der",
+                },
+                privateKeyEncoding: {
+                    type: "pkcs8",
+                    format: "der",
+                },
+            });
+
+            const keyBuffer = Buffer.from(publicKey);
+            process.env.DECRYPTION_KEY_ID = "abc123";
+
+            const mockKMSClient = mockClient(KMSClient);
+            mockKMSClient.on(GetPublicKeyCommand, { KeyId: "abc123" }).resolvesOnce({ PublicKey: keyBuffer });
+
+            const result = await getPublicEncryptionKey(audience);
+            expect(result).toBeDefined();
+            expect(result?.type).toBe("public");
         });
     });
 
@@ -72,9 +131,9 @@ describe("crypto-service", () => {
             const mockKMSClient = mockClient(KMSClient);
             mockKMSClient.on(GetPublicKeyCommand, { KeyId: "abc123" }).resolvesOnce({ PublicKey: keyBuffer });
 
-            const publicEncryptionKey = await getPublicEncryptionKey();
+            const publicEncryptionKey = await getPublicEncryptionKey(audience);
 
-            const result = await encryptSignedJwt(TestData.jwt, publicEncryptionKey);
+            const result = await encryptSignedJwt(TestData.jwt, publicEncryptionKey as KeyLike);
             expect(result).toMatch(
                 /^eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/g,
             );

--- a/test-resources/headless-core-stub/utils/src/audience-formatter/index.ts
+++ b/test-resources/headless-core-stub/utils/src/audience-formatter/index.ts
@@ -1,0 +1,7 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+export const formatAudience = (audience: string, logger?: Logger) => {
+    const audienceApi = audience.includes("review-") ? audience.replace("review-", "api.review-") : audience;
+
+    logger?.info({ message: "Using Audience", audienceApi });
+    return audienceApi;
+};

--- a/test-resources/headless-core-stub/utils/tests/audience-formatter/index.test.ts
+++ b/test-resources/headless-core-stub/utils/tests/audience-formatter/index.test.ts
@@ -1,0 +1,41 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { formatAudience } from "../../src/audience-formatter";
+
+describe("formatAudience", () => {
+    it("replaces 'review-' with 'api.review-'", () => {
+        const expected = "https://api.review-example.co.uk";
+
+        const actual = formatAudience("https://review-example.co.uk");
+
+        expect(actual).toBe(expected);
+    });
+
+    it("returns input unchanged if 'review-' is not present", () => {
+        const input = "https://example.co.uk";
+
+        const actual = formatAudience(input);
+
+        expect(actual).toBe(input);
+    });
+
+    it("logs when logger is provided", () => {
+        const logger: Logger = { info: jest.fn() } as unknown as Logger;
+
+        formatAudience("https://review-example.co.uk", logger);
+
+        expect(logger.info).toHaveBeenCalledWith({
+            message: "Using Audience",
+            audienceApi: "https://api.review-example.co.uk",
+        });
+    });
+
+    it("does not throw or log if logger is not provided", () => {
+        expect(() => formatAudience("https://review-example.co.uk")).not.toThrow();
+    });
+
+    it("handles empty string input gracefully", () => {
+        const result = formatAudience("");
+
+        expect(result).toBe("");
+    });
+});

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -32,25 +32,41 @@ Parameters:
     Default: common-cri-api
 
 Mappings:
+  KeyRotationMapping:
+    di-ipv-cri-address-api:
+      dev: true
+      build: true
+      staging: true
+      integration: false
+      production: false
+    di-ipv-cri-kbv-api:
+      dev: true
+      build: true
+      staging: true
+      integration: false
+      production: false
+    di-ipv-cri-check-hmrc-api:
+      dev: false
+      build: false
+      staging: false
+      integration: false
+      production: false
   TestHarnessUrl:
-      di-ipv-cri-check-hmrc-api:
-        localdev: review-hc.dev.account.gov.uk
-        dev: review-hc.dev.account.gov.uk
-        build: review-hc.build.account.gov.uk
-        staging: review-hc.staging.account.gov.uk
-        integration: review-hc.integration.account.gov.uk
-      di-ipv-cri-address-api:
-        localdev: review-a.dev.account.gov.uk
-        dev: review-a.dev.account.gov.uk
-        build: review-a.build.account.gov.uk
-        staging: review-a.staging.account.gov.uk
-        integration: review-a.integration.account.gov.uk
-      di-ipv-cri-kbv-api:
-        localdev: review-k.dev.account.gov.uk
-        dev: review-k.dev.account.gov.uk
-        build: review-k.build.account.gov.uk
-        staging: review-k.staging.account.gov.uk
-        integration: review-k.integration.account.gov.uk
+    di-ipv-cri-check-hmrc-api:
+      localdev: review-hc.dev.account.gov.uk
+      dev: review-hc.dev.account.gov.uk
+      build: review-hc.build.account.gov.uk
+      staging: review-hc.staging.account.gov.uk
+    di-ipv-cri-address-api:
+      localdev: review-a.dev.account.gov.uk
+      dev: review-a.dev.account.gov.uk
+      build: review-a.build.account.gov.uk
+      staging: review-a.staging.account.gov.uk
+    di-ipv-cri-kbv-api:
+      localdev: review-k.dev.account.gov.uk
+      dev: review-k.dev.account.gov.uk
+      build: review-k.build.account.gov.uk
+      staging: review-k.staging.account.gov.uk
   CriVpcMapping:
     di-ipv-cri-check-hmrc-api:
       pipeline: "di-devplatform-deploy"
@@ -172,6 +188,7 @@ Resources:
           POWERTOOLS_SERVICE_NAME: HeadlessCoreStubStartFunction
           DECRYPTION_KEY_ID: !ImportValue core-infrastructure-CriDecryptionKey1Id
           TEST_RESOURCES_STACK_NAME: !Sub ${AWS::StackName}
+          KEY_ROTATION_FEATURE_FLAG_ENABLED: !FindInMap [ KeyRotationMapping, !Ref CriIdentifier, !Ref Environment ]
       Policies:
         - Statement:
             Effect: Allow


### PR DESCRIPTION
## Proposed changes

Added functionality to call the hosted .well-known/jwks.json of the CRI.
The headless core stub using the jwk to encrypt the JAR

### What changed

The Key-rotation step function has been run and a bootstrap key is available for use, which can be used to encrypt the payload by the headless core stub. The CRI should be able to decrypt this request when it comes throught the session handler

### Why did it change

A valid ./well-known/jwks.json exist at https://api.review-a.dev.account.gov.uk/.well-known/jwks.json

![image](https://github.com/user-attachments/assets/fd59bc57-f064-4e15-aa36-3da2e22dc028)


### Issue tracking

- [OJ-2969](https://govukverify.atlassian.net/browse/OJ-2969)



### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2969]: https://govukverify.atlassian.net/browse/OJ-2969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ