### PR TITLE
feat: do not dequeue events in staging & integration

### DIFF
--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -20,8 +20,8 @@ Parameters:
   Environment:
     Type: String
     Default: dev
-    AllowedValues: [dev, localdev, build, staging]
-    ConstraintDescription: must be dev, localdev, build or staging
+    AllowedValues: [dev, localdev, build, staging, integration]
+    ConstraintDescription: must be dev, localdev, build, staging, integration
   VpcStackName:
     Type: String
     Default: "cri-vpc"

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -65,7 +65,11 @@ Metadata:
 Conditions:
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]
-  DequeueEvents: !Not [!Equals [!Ref Environment, localdev]]
+  DequeueEvents: !And
+    - !Not [!Equals [!Ref Environment, localdev]]
+    - !Not [!Equals [!Ref Environment, staging]]
+    - !Not [!Equals [!Ref Environment, integration]]
+
   # Don't create domain resources for the common dev account as there are none
   CreateDomainResources: !Not [!Equals [!Sub "${AWS::AccountId}", "486210938254"]]
   IsDevPlatformDeploy: !Equals [ !FindInMap [ CriVpcMapping, !Ref CriIdentifier, "pipeline"  ], "di-devplatform-deploy" ]


### PR DESCRIPTION
## Proposed changes

### Why did it change
Set DequeueEvents to false when the environment is staging/integration as we do not want events being dequeued in those environments.

Added integration to the AllowedValues for Environment parameter to match this. 

### Issue tracking
- [OJ-3171](https://govukverify.atlassian.net/browse/OJ-3171)


[OJ-3171]: https://govukverify.atlassian.net/browse/OJ-3171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ