### PR TITLE
OJ-3158: use cri published keys

### DIFF
--- a/test-resources/headless-core-stub/lambdas/callback/src/callback-handler.ts
+++ b/test-resources/headless-core-stub/lambdas/callback/src/callback-handler.ts
@@ -9,6 +9,7 @@ import { handleErrorResponse } from "../../../utils/src/errors/error-response";
 import { ClientConfiguration } from "../../../utils/src/services/client-configuration";
 import { base64Decode } from "../../../utils/src/base64";
 import { DEFAULT_CLIENT_ID } from "../../../utils/src/constants";
+import { formatAudience } from "../../../utils/src/audience-formatter";
 
 const logger = new Logger({ serviceName: "CallBackService" });
 const callback = new CallBackService(logger);
@@ -29,7 +30,7 @@ export class CallbackLambdaHandler implements LambdaInterface {
             const audience = statePayload.audience || ssmParameters.audience;
             const redirectUri = statePayload.redirectUri || ssmParameters.redirectUri;
 
-            const audienceApi = this.formatAudience(audience);
+            const audienceApi = formatAudience(audience, logger);
             const tokenEndpoint = `${audienceApi}/token`;
 
             logger.info({ message: "Generating private JWT parameters" });
@@ -81,12 +82,6 @@ export class CallbackLambdaHandler implements LambdaInterface {
 
     private excludeFromRecord = (record: Record<string, string>, excludeKey: string): Record<string, string> => {
         return Object.fromEntries(Object.entries(record).filter(([key]) => key !== excludeKey));
-    };
-    private formatAudience = (audience: string) => {
-        const audienceApi = audience.includes("review-") ? audience.replace("review-", "api.review-") : audience;
-
-        logger.info({ message: "Using Audience", audienceApi });
-        return audienceApi;
     };
 }
 

--- a/test-resources/headless-core-stub/lambdas/mock-jwks/src/mock-jwk-handler.ts
+++ b/test-resources/headless-core-stub/lambdas/mock-jwks/src/mock-jwk-handler.ts
@@ -19,7 +19,7 @@ export class MockJwkHandler implements LambdaInterface {
                     statusCode: 200,
                     body: JSON.stringify(jwks),
                     headers: {
-                        "Cache-Control": "max-age=900",
+                        "Cache-Control": "max-age=300",
                     },
                 };
             }

--- a/test-resources/headless-core-stub/lambdas/start/src/services/signing-service.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/services/signing-service.ts
@@ -1,16 +1,72 @@
 import { GetPublicKeyCommand, KMSClient } from "@aws-sdk/client-kms";
-import { CompactEncrypt, importSPKI, KeyLike } from "jose";
+import { CompactEncrypt, importJWK, importSPKI, JSONWebKeySet, JWK, KeyLike } from "jose";
 import { HeadlessCoreStubError } from "../../../../utils/src/errors/headless-core-stub-error";
+import { formatAudience } from "../../../../utils/src/audience-formatter";
+import { Logger } from "@aws-lambda-powertools/logger";
 
 const kmsClient = new KMSClient({ region: "eu-west-2" });
+export const logger = new Logger();
 
 let cachedPublicKey: KeyLike | undefined;
 
-export const getPublicEncryptionKey = async () => {
+export const getPublicEncryptionKey = async (audience: string) => {
     if (cachedPublicKey) {
         return cachedPublicKey;
     }
 
+    if (process.env.KEY_ROTATION_FEATURE_FLAG_ENABLED === "true") {
+        await getPublicEncryptionKeyJwksUri(audience);
+    }
+
+    if (!cachedPublicKey) {
+        logger.info({ message: "using KMS to retrieve encryption key" });
+        await getPublicEncryptionKeyFromKms();
+    }
+
+    return cachedPublicKey;
+};
+
+export const encryptSignedJwt = (signedJwt: string, publicEncryptionKey: KeyLike) => {
+    return new CompactEncrypt(new TextEncoder().encode(signedJwt))
+        .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM" })
+        .encrypt(publicEncryptionKey);
+};
+
+export function _resetCachedPublicKeyForTest() {
+    cachedPublicKey = undefined;
+}
+
+async function getPublicEncryptionKeyJwksUri(audience: string) {
+    const audienceApi = formatAudience(audience);
+    const criEncryptionJwksEndpoint = new URL("/.well-known/jwks.json", audienceApi).href;
+
+    logger.info({ message: "Attempting to use CRI hosted public encryption jwks endpoint", criEncryptionJwksEndpoint });
+
+    const data = await fetch(criEncryptionJwksEndpoint, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+    });
+
+    if (!data.ok) {
+        throw new Error(`Failed to fetch JWKS: ${data.status} ${data.statusText}`);
+    }
+
+    const jwks = (await data.json()) as JSONWebKeySet;
+
+    if (!jwks.keys || !Array.isArray(jwks.keys) || jwks.keys.length === 0) {
+        throw new Error(`Invalid or empty JWKS response from ${criEncryptionJwksEndpoint}`);
+    }
+    logger.info({ message: "Successfully retrieved public encryption jwks endpoint", ...jwks });
+
+    const encryptionKey = jwks.keys
+        .slice()
+        .reverse()
+        .find((k) => k.use === "enc") as JWK;
+
+    cachedPublicKey = encryptionKey && ((await importJWK(encryptionKey, "RSA-OAEP-256")) as KeyLike);
+}
+
+async function getPublicEncryptionKeyFromKms() {
     const decryptionKeyId = process.env.DECRYPTION_KEY_ID;
     if (!decryptionKeyId) {
         throw new HeadlessCoreStubError("Decryption key ID not present", 500);
@@ -28,11 +84,4 @@ export const getPublicEncryptionKey = async () => {
     const publicKeyPem = `${header}\n${value}\n${footer}`;
 
     cachedPublicKey = await importSPKI(publicKeyPem, "RS256");
-    return cachedPublicKey;
-};
-
-export const encryptSignedJwt = (signedJwt: string, publicEncryptionKey: KeyLike) => {
-    return new CompactEncrypt(new TextEncoder().encode(signedJwt))
-        .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM" })
-        .encrypt(publicEncryptionKey);
-};
+}

--- a/test-resources/headless-core-stub/lambdas/start/src/start-handler.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/start-handler.ts
@@ -34,7 +34,7 @@ export class StartLambdaHandler implements LambdaInterface {
             };
             const signedJwt = await signJwt(jwtClaimsSet as JWTPayload, signingKey, jwtHeader);
 
-            const publicEncryptionKey: KeyLike = await getPublicEncryptionKey();
+            const publicEncryptionKey = (await getPublicEncryptionKey(jwtClaimsSet.aud)) as KeyLike;
 
             const encryptedSignedJwt = await encryptSignedJwt(signedJwt, publicEncryptionKey);
 

--- a/test-resources/headless-core-stub/lambdas/start/tests/services/signing-service.test.ts
+++ b/test-resources/headless-core-stub/lambdas/start/tests/services/signing-service.test.ts
@@ -1,29 +1,72 @@
-import { clearCaches } from "@aws-lambda-powertools/parameters";
 import { GetPublicKeyCommand, KMSClient } from "@aws-sdk/client-kms";
 import { mockClient } from "aws-sdk-client-mock";
 import { generateKeyPairSync } from "crypto";
 import { HeadlessCoreStubError } from "../../../../utils/src/errors/headless-core-stub-error";
-import { encryptSignedJwt, getPublicEncryptionKey } from "../../src/services/signing-service";
+import {
+    encryptSignedJwt,
+    getPublicEncryptionKey,
+    _resetCachedPublicKeyForTest,
+} from "../../src/services/signing-service";
 import { TestData } from "../../../../utils/tests/test-data";
 
-describe("crypto-service", () => {
-    describe("getPublicEncryptionKey", () => {
-        const mockKMSClient = mockClient(KMSClient);
+import * as jose from "jose";
+describe("signing-service", () => {
+    const audience = "https://test-audience.com";
+    const mockKMSClient = mockClient(KMSClient);
+    let originalFetch: typeof global.fetch;
 
-        afterEach(() => {
-            mockKMSClient.reset();
-            clearCaches();
+    const resetEnvironment = () => {
+        _resetCachedPublicKeyForTest();
+        mockKMSClient.reset();
+        jest.restoreAllMocks();
+        delete process.env.KEY_ROTATION_FEATURE_FLAG_ENABLED;
+        delete process.env.DECRYPTION_KEY_ID;
+        global.fetch = originalFetch;
+    };
+
+    beforeEach(() => {
+        originalFetch = global.fetch;
+        jest.resetModules();
+        _resetCachedPublicKeyForTest();
+    });
+
+    afterEach(() => {
+        resetEnvironment();
+    });
+
+    describe("encryptSignedJwt", () => {
+        it("creates encrypted signed jwt", async () => {
+            const { publicKey } = generateKeyPairSync("rsa", {
+                modulusLength: 2048,
+                publicKeyEncoding: { type: "spki", format: "der" },
+                privateKeyEncoding: { type: "pkcs8", format: "der" },
+            });
+
+            const keyBuffer = Buffer.from(publicKey);
+            process.env.DECRYPTION_KEY_ID = "abc123";
+
+            mockKMSClient.on(GetPublicKeyCommand, { KeyId: "abc123" }).resolvesOnce({ PublicKey: keyBuffer });
+
+            const publicEncryptionKey = await getPublicEncryptionKey(audience);
+            const result = await encryptSignedJwt(TestData.jwt, publicEncryptionKey as jose.KeyLike);
+
+            expect(result).toMatch(
+                /^eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/g,
+            );
         });
+    });
 
+    describe("getPublicEncryptionKey - kms", () => {
         it("throws error with 500 if decryption key env variable not set", async () => {
-            await expect(getPublicEncryptionKey()).rejects.toThrow(
+            await expect(getPublicEncryptionKey(audience)).rejects.toThrow(
                 new HeadlessCoreStubError("Decryption key ID not present", 500),
             );
         });
 
         it("throws error with 500 if kms key not retrieved", async () => {
             process.env.DECRYPTION_KEY_ID = "abc123";
-            await expect(getPublicEncryptionKey()).rejects.toThrow(
+
+            await expect(getPublicEncryptionKey(audience)).rejects.toThrow(
                 new HeadlessCoreStubError("Unable to retrieve public encryption key", 500),
             );
         });
@@ -31,53 +74,198 @@ describe("crypto-service", () => {
         it("retrieves public encryption key", async () => {
             const { publicKey } = generateKeyPairSync("rsa", {
                 modulusLength: 2048,
-                publicKeyEncoding: {
-                    type: "spki",
-                    format: "der",
-                },
-                privateKeyEncoding: {
-                    type: "pkcs8",
-                    format: "der",
-                },
+                publicKeyEncoding: { type: "spki", format: "der" },
+                privateKeyEncoding: { type: "pkcs8", format: "der" },
             });
-            const keyBuffer = Buffer.from(publicKey);
 
             process.env.DECRYPTION_KEY_ID = "abc123";
+            const keyBuffer = Buffer.from(publicKey);
 
-            const mockKMSClient = mockClient(KMSClient);
             mockKMSClient.on(GetPublicKeyCommand, { KeyId: "abc123" }).resolvesOnce({ PublicKey: keyBuffer });
 
-            const result = await getPublicEncryptionKey();
-            expect(result.type).toEqual("public");
+            const result = await getPublicEncryptionKey(audience);
+            expect(result?.type).toEqual("public");
         });
     });
 
-    describe("encryptSignedJwt", () => {
-        it("creates encrypted signed jwt", async () => {
+    describe("getPublicEncryptionKey - jwks uri", () => {
+        beforeEach(() => {
+            process.env.KEY_ROTATION_FEATURE_FLAG_ENABLED = "true";
+        });
+
+        it("retrieves the last public encryption key from JWKS", async () => {
+            const mockJwks = {
+                keys: [
+                    { kty: "RSA", e: "AQAB", use: "enc", alg: "RS256", n: "dummy-n", kid: "dummy-kid" },
+                    { kty: "RSA", e: "AQAB", use: "enc", alg: "RS256", n: "dummy-n", kid: "dummy-kid_2" },
+                ],
+            };
+
+            global.fetch = jest.fn().mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(mockJwks),
+            });
+
+            const spyImportJWK = jest.spyOn(jose, "importJWK").mockImplementation(async (key: jose.JWK) => {
+                expect(key?.kid).toBe("dummy-kid_2");
+                return { type: "public" } as jose.KeyLike;
+            });
+
+            const result = await getPublicEncryptionKey(audience);
+            expect(result?.type).toBe("public");
+            expect(spyImportJWK).toHaveBeenCalledWith(expect.objectContaining({ kid: "dummy-kid_2" }), "RSA-OAEP-256");
+        });
+
+        it("retrieves public encryption key from JWKS endpoint", async () => {
+            const mockJwks = {
+                keys: [{ kty: "RSA", e: "AQAB", use: "enc", alg: "RS256", n: "dummy-n", kid: "dummy-kid" }],
+            };
+
+            global.fetch = jest.fn().mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(mockJwks),
+            });
+
+            const result = await getPublicEncryptionKey(audience);
+            expect(result).toBeDefined();
+            expect(result?.type).toBe("public");
+        });
+
+        it("falls back to KMS if JWKS with enc isn't found", async () => {
+            const mockJwks = {
+                keys: [
+                    {
+                        kty: "EC",
+                        use: "sig",
+                        crv: "P-256",
+                        kid: "74c5",
+                        x: "x",
+                        y: "y",
+                        alg: "ES256",
+                    },
+                ],
+            };
+
             const { publicKey } = generateKeyPairSync("rsa", {
                 modulusLength: 2048,
-                publicKeyEncoding: {
-                    type: "spki",
-                    format: "der",
-                },
-                privateKeyEncoding: {
-                    type: "pkcs8",
-                    format: "der",
-                },
+                publicKeyEncoding: { type: "spki", format: "der" },
+                privateKeyEncoding: { type: "pkcs8", format: "der" },
             });
-            const keyBuffer = Buffer.from(publicKey);
+
+            global.fetch = jest.fn().mockResolvedValueOnce({
+                ok: true,
+                json: () => Promise.resolve(mockJwks),
+            });
 
             process.env.DECRYPTION_KEY_ID = "abc123";
+            const keyBuffer = Buffer.from(publicKey);
 
-            const mockKMSClient = mockClient(KMSClient);
             mockKMSClient.on(GetPublicKeyCommand, { KeyId: "abc123" }).resolvesOnce({ PublicKey: keyBuffer });
 
-            const publicEncryptionKey = await getPublicEncryptionKey();
+            const result = await getPublicEncryptionKey(audience);
+            expect(result?.type).toBe("public");
+        });
 
-            const result = await encryptSignedJwt(TestData.jwt, publicEncryptionKey);
-            expect(result).toMatch(
-                /^eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/g,
-            );
+        it("falls back to KMS if JWKS fetch fails", async () => {
+            process.env.KEY_ROTATION_FEATURE_FLAG_ENABLED = "false";
+
+            const { publicKey } = generateKeyPairSync("rsa", {
+                modulusLength: 2048,
+                publicKeyEncoding: { type: "spki", format: "der" },
+                privateKeyEncoding: { type: "pkcs8", format: "der" },
+            });
+
+            const keyBuffer = Buffer.from(publicKey);
+            process.env.DECRYPTION_KEY_ID = "abc123";
+
+            mockKMSClient.on(GetPublicKeyCommand, { KeyId: "abc123" }).resolvesOnce({ PublicKey: keyBuffer });
+
+            const result = await getPublicEncryptionKey(audience);
+            expect(result?.type).toBe("public");
+        });
+    });
+
+    describe("getPublicEncryptionKey caching behavior", () => {
+        it("fetches key only once from JWKS when called multiple times", async () => {
+            process.env.KEY_ROTATION_FEATURE_FLAG_ENABLED = "true";
+
+            const mockJwks = {
+                keys: [{ kty: "RSA", e: "AQAB", use: "enc", alg: "RS256", n: "mocked-n", kid: "mocked-kid" }],
+            };
+
+            const fetchSpy = jest.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve(mockJwks),
+            });
+
+            global.fetch = fetchSpy;
+            const importSpy = jest.spyOn(jose, "importJWK").mockResolvedValue({ type: "public" } as jose.KeyLike);
+
+            const key1 = await getPublicEncryptionKey(audience);
+            const key2 = await getPublicEncryptionKey(audience);
+
+            expect(key1).toEqual(key2);
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+            expect(importSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("refetches after cache reset", async () => {
+            process.env.KEY_ROTATION_FEATURE_FLAG_ENABLED = "true";
+
+            const mockJwks = {
+                keys: [{ kty: "RSA", e: "AQAB", use: "enc", alg: "RS256", n: "mocked-n", kid: "mocked-kid" }],
+            };
+
+            const fetchSpy = jest.fn().mockResolvedValue({
+                ok: true,
+                json: () => Promise.resolve(mockJwks),
+            });
+
+            global.fetch = fetchSpy;
+            jest.spyOn(jose, "importJWK").mockResolvedValue({ type: "public" } as jose.KeyLike);
+
+            await getPublicEncryptionKey(audience);
+            _resetCachedPublicKeyForTest();
+            await getPublicEncryptionKey(audience);
+
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it("falls back to KMS if no JWKS encryption key is found and caches it", async () => {
+            process.env.KEY_ROTATION_FEATURE_FLAG_ENABLED = "true";
+            process.env.DECRYPTION_KEY_ID = "abc123";
+
+            const mockJwks = {
+                keys: [{ kty: "RSA", e: "AQAB", use: "sig", alg: "RS256", n: "ignored" }],
+            };
+
+            const { publicKey } = generateKeyPairSync("rsa", {
+                modulusLength: 2048,
+                publicKeyEncoding: { type: "spki", format: "der" },
+                privateKeyEncoding: { type: "pkcs8", format: "der" },
+            });
+
+            const keyBuffer = Buffer.from(publicKey);
+
+            global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(mockJwks) });
+            mockKMSClient.on(GetPublicKeyCommand, { KeyId: "abc123" }).resolvesOnce({ PublicKey: keyBuffer });
+
+            const importSpy = jest.spyOn(jose, "importSPKI").mockResolvedValue({ type: "public" } as jose.KeyLike);
+
+            const key1 = await getPublicEncryptionKey(audience);
+            const key2 = await getPublicEncryptionKey(audience);
+
+            expect(key1).toEqual(key2);
+            expect(importSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("throws if KMS fails and cache is not set", async () => {
+            process.env.KEY_ROTATION_FEATURE_FLAG_ENABLED = "false";
+            process.env.DECRYPTION_KEY_ID = "abc123";
+
+            mockKMSClient.on(GetPublicKeyCommand, { KeyId: "abc123" }).resolves({ PublicKey: undefined });
+
+            await expect(getPublicEncryptionKey(audience)).rejects.toThrow("Unable to retrieve public encryption key");
         });
     });
 });

--- a/test-resources/headless-core-stub/utils/src/audience-formatter/index.ts
+++ b/test-resources/headless-core-stub/utils/src/audience-formatter/index.ts
@@ -1,0 +1,7 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+export const formatAudience = (audience: string, logger?: Logger) => {
+    const audienceApi = audience.includes("review-") ? audience.replace("review-", "api.review-") : audience;
+
+    logger?.info({ message: "Using Audience", audienceApi });
+    return audienceApi;
+};

--- a/test-resources/headless-core-stub/utils/src/jwks-cache-control/index.ts
+++ b/test-resources/headless-core-stub/utils/src/jwks-cache-control/index.ts
@@ -1,0 +1,32 @@
+import { JSONWebKeySet } from "jose";
+
+let cachedJWKS: JSONWebKeySet | null = null;
+let cachedJWKSExpiry: number | null = null;
+
+export const isJWKSCacheValid = () => Boolean(cachedJWKS && cachedJWKSExpiry && cachedJWKSExpiry >= Date.now());
+
+export const parseCacheControlMaxAge = (cacheControlHeaderValue?: string): number => {
+    const match = cacheControlHeaderValue?.match(/max-age=(\d+)/);
+    const maxAgeSeconds = match ? parseInt(match[1], 10) : -1;
+    return Date.now() + maxAgeSeconds * 1000;
+};
+
+export const fetchAndCacheJWKS = async (jwksUrl: URL, logger: { info: (msg: string) => void }) => {
+    const jwksResponse = await fetch(jwksUrl);
+    if (!jwksResponse.ok) {
+        throw new Error(
+            `Error received from the JWKS endpoint, status received: ${jwksResponse.status} ${jwksResponse.statusText}`,
+        );
+    }
+
+    cachedJWKS = (await jwksResponse.json()) as JSONWebKeySet;
+    cachedJWKSExpiry = parseCacheControlMaxAge(jwksResponse?.headers?.get("Cache-Control") as string);
+    logger.info(`JWKS cache has been updated to  ${cachedJWKSExpiry}`);
+};
+
+export const clearJWKSCache = () => {
+    cachedJWKS = null;
+    cachedJWKSExpiry = null;
+};
+
+export const getCachedJWKS = () => cachedJWKS;

--- a/test-resources/headless-core-stub/utils/tests/audience-formatter/index.test.ts
+++ b/test-resources/headless-core-stub/utils/tests/audience-formatter/index.test.ts
@@ -1,0 +1,41 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { formatAudience } from "../../src/audience-formatter";
+
+describe("formatAudience", () => {
+    it("replaces 'review-' with 'api.review-'", () => {
+        const expected = "https://api.review-example.co.uk";
+
+        const actual = formatAudience("https://review-example.co.uk");
+
+        expect(actual).toBe(expected);
+    });
+
+    it("returns input unchanged if 'review-' is not present", () => {
+        const input = "https://example.co.uk";
+
+        const actual = formatAudience(input);
+
+        expect(actual).toBe(input);
+    });
+
+    it("logs when logger is provided", () => {
+        const logger: Logger = { info: jest.fn() } as unknown as Logger;
+
+        formatAudience("https://review-example.co.uk", logger);
+
+        expect(logger.info).toHaveBeenCalledWith({
+            message: "Using Audience",
+            audienceApi: "https://api.review-example.co.uk",
+        });
+    });
+
+    it("does not throw or log if logger is not provided", () => {
+        expect(() => formatAudience("https://review-example.co.uk")).not.toThrow();
+    });
+
+    it("handles empty string input gracefully", () => {
+        const result = formatAudience("");
+
+        expect(result).toBe("");
+    });
+});

--- a/test-resources/headless-core-stub/utils/tests/jwks-cache-control/index.test.ts
+++ b/test-resources/headless-core-stub/utils/tests/jwks-cache-control/index.test.ts
@@ -1,0 +1,111 @@
+import { JSONWebKeySet } from "jose";
+import {
+    clearJWKSCache,
+    parseCacheControlMaxAge,
+    isJWKSCacheValid,
+    getCachedJWKS,
+    fetchAndCacheJWKS,
+} from "../../src/jwks-cache-control";
+
+global.fetch = jest.fn();
+
+const mockLogger = {
+    info: jest.fn(),
+};
+
+const fakeJWKS: JSONWebKeySet = {
+    keys: [
+        {
+            kty: "RSA",
+            kid: "test-key-id",
+            use: "enc",
+            n: "some-modulus",
+            e: "AQAB",
+        },
+    ],
+};
+
+const fetchMock = fetch as jest.Mock;
+describe("JWKS Cache Control", () => {
+    beforeEach(() => {
+        clearJWKSCache();
+        jest.clearAllMocks();
+    });
+
+    describe("parseCacheControlMaxAge", () => {
+        it("parses valid max-age correctly", () => {
+            const now = Date.now();
+            const result = parseCacheControlMaxAge("public, max-age=60");
+
+            expect(result).toBeGreaterThanOrEqual(now + 60000);
+            expect(result).toBeLessThanOrEqual(now + 61000);
+        });
+
+        it("returns expiry in the past for invalid input", () => {
+            const result = parseCacheControlMaxAge(undefined);
+
+            expect(result).toBeLessThan(Date.now());
+        });
+
+        it("returns expiry in the past if max-age is not present", () => {
+            const result = parseCacheControlMaxAge("no-cache");
+
+            expect(result).toBeLessThan(Date.now());
+        });
+    });
+
+    describe("JWKS cache operations", () => {
+        it("initially has no valid cache", () => {
+            expect(isJWKSCacheValid()).toBe(false);
+
+            expect(getCachedJWKS()).toBeNull();
+        });
+
+        it("fetches and caches JWKS", async () => {
+            const mockResponse = {
+                ok: true,
+                json: async () => fakeJWKS,
+                headers: {
+                    get: () => "max-age=60",
+                },
+            };
+
+            fetchMock.mockResolvedValueOnce(mockResponse);
+
+            await fetchAndCacheJWKS(new URL("https://a-cri-endpoint.co.uk/.well-known/jwks.json"), mockLogger);
+
+            expect(getCachedJWKS()).toEqual(fakeJWKS);
+            expect(isJWKSCacheValid()).toBe(true);
+            expect(mockLogger.info).toHaveBeenCalledWith(expect.stringMatching(/JWKS cache has been updated/));
+        });
+
+        it("throws if fetch fails", async () => {
+            fetchMock.mockResolvedValueOnce({
+                ok: false,
+                status: 500,
+            });
+
+            await expect(
+                fetchAndCacheJWKS(new URL("https://a-cri-endpoint.co.uk/.well-known/jwks.json"), mockLogger),
+            ).rejects.toThrow("Error received from the JWKS endpoint, status received: 500");
+        });
+
+        it("clears the cache", async () => {
+            const mockResponse = {
+                ok: true,
+                json: async () => fakeJWKS,
+                headers: {
+                    get: () => "max-age=60",
+                },
+            };
+
+            fetchMock.mockResolvedValueOnce(mockResponse);
+            await fetchAndCacheJWKS(new URL("https://example.com"), mockLogger);
+
+            clearJWKSCache();
+
+            expect(isJWKSCacheValid()).toBe(false);
+            expect(getCachedJWKS()).toBeNull();
+        });
+    });
+});

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -40,9 +40,9 @@ Mappings:
       integration: false
       production: false
     di-ipv-cri-kbv-api:
-      dev: true
-      build: true
-      staging: true
+      dev: false
+      build: false
+      staging: false
       integration: false
       production: false
     di-ipv-cri-check-hmrc-api:
@@ -51,22 +51,27 @@ Mappings:
       staging: false
       integration: false
       production: false
+
   TestHarnessUrl:
     di-ipv-cri-check-hmrc-api:
       localdev: review-hc.dev.account.gov.uk
       dev: review-hc.dev.account.gov.uk
       build: review-hc.build.account.gov.uk
       staging: review-hc.staging.account.gov.uk
+      integration: review-hc.integration.account.gov.uk
     di-ipv-cri-address-api:
       localdev: review-a.dev.account.gov.uk
       dev: review-a.dev.account.gov.uk
       build: review-a.build.account.gov.uk
       staging: review-a.staging.account.gov.uk
+      integration: review-a.integration.account.gov.uk
     di-ipv-cri-kbv-api:
       localdev: review-k.dev.account.gov.uk
       dev: review-k.dev.account.gov.uk
       build: review-k.build.account.gov.uk
       staging: review-k.staging.account.gov.uk
+      integration: review-k.integration.account.gov.uk
+
   CriVpcMapping:
     di-ipv-cri-check-hmrc-api:
       pipeline: "di-devplatform-deploy"

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -32,25 +32,41 @@ Parameters:
     Default: common-cri-api
 
 Mappings:
+  KeyRotationMapping:
+    di-ipv-cri-address-api:
+      dev: true
+      build: true
+      staging: true
+      integration: false
+      production: false
+    di-ipv-cri-kbv-api:
+      dev: true
+      build: true
+      staging: true
+      integration: false
+      production: false
+    di-ipv-cri-check-hmrc-api:
+      dev: false
+      build: false
+      staging: false
+      integration: false
+      production: false
   TestHarnessUrl:
-      di-ipv-cri-check-hmrc-api:
-        localdev: review-hc.dev.account.gov.uk
-        dev: review-hc.dev.account.gov.uk
-        build: review-hc.build.account.gov.uk
-        staging: review-hc.staging.account.gov.uk
-        integration: review-hc.integration.account.gov.uk
-      di-ipv-cri-address-api:
-        localdev: review-a.dev.account.gov.uk
-        dev: review-a.dev.account.gov.uk
-        build: review-a.build.account.gov.uk
-        staging: review-a.staging.account.gov.uk
-        integration: review-a.integration.account.gov.uk
-      di-ipv-cri-kbv-api:
-        localdev: review-k.dev.account.gov.uk
-        dev: review-k.dev.account.gov.uk
-        build: review-k.build.account.gov.uk
-        staging: review-k.staging.account.gov.uk
-        integration: review-k.integration.account.gov.uk
+    di-ipv-cri-check-hmrc-api:
+      localdev: review-hc.dev.account.gov.uk
+      dev: review-hc.dev.account.gov.uk
+      build: review-hc.build.account.gov.uk
+      staging: review-hc.staging.account.gov.uk
+    di-ipv-cri-address-api:
+      localdev: review-a.dev.account.gov.uk
+      dev: review-a.dev.account.gov.uk
+      build: review-a.build.account.gov.uk
+      staging: review-a.staging.account.gov.uk
+    di-ipv-cri-kbv-api:
+      localdev: review-k.dev.account.gov.uk
+      dev: review-k.dev.account.gov.uk
+      build: review-k.build.account.gov.uk
+      staging: review-k.staging.account.gov.uk
   CriVpcMapping:
     di-ipv-cri-check-hmrc-api:
       pipeline: "di-devplatform-deploy"
@@ -172,6 +188,7 @@ Resources:
           POWERTOOLS_SERVICE_NAME: HeadlessCoreStubStartFunction
           DECRYPTION_KEY_ID: !ImportValue core-infrastructure-CriDecryptionKey1Id
           TEST_RESOURCES_STACK_NAME: !Sub ${AWS::StackName}
+          KEY_ROTATION_FEATURE_FLAG_ENABLED: !FindInMap [ KeyRotationMapping, !Ref CriIdentifier, !Ref Environment ]
       Policies:
         - Statement:
             Effect: Allow


### PR DESCRIPTION
## Proposed changes

Added functionality to call the hosted .well-known/jwks.json of the CRI.
The headless core stub using the jwk to encrypt the JAR

### What changed

The Key-rotation step function has been run and a bootstrap key is available for use, which can be used to encrypt the payload by the headless core stub. The CRI should be able to decrypt this request when it comes throught the session handler

### Why did it change

A valid ./well-known/jwks.json exist at https://api.review-a.dev.account.gov.uk/.well-known/jwks.json

![image](https://github.com/user-attachments/assets/fd59bc57-f064-4e15-aa36-3da2e22dc028)


### Issue tracking

- [OJ-3158](https://govukverify.atlassian.net/browse/OJ-3158)



### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3158]: https://govukverify.atlassian.net/browse/OJ-3158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ