### PR TITLE
feat: enable KeyRotationMapping for address-dev

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -281,7 +281,7 @@ Mappings:
 # Use key rotation aliases in session decryption
   KeyRotationMapping:
     di-ipv-cri-address-api:
-      dev: "false"
+      dev: "true"
       build: "false"
       staging: "false"
       integration: "false"


### PR DESCRIPTION
## Proposed changes

### What changed
Enable KeyRotationMapping in address-dev

### Why did it change
To use the key rotation work that lime implemented.

### Issue tracking
- [OJ-3143](https://govukverify.atlassian.net/browse/OJ-3143)


[OJ-3143]: https://govukverify.atlassian.net/browse/OJ-3143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ