### PR TITLE
OJ-3175: Bump cri-lib to include ssm jwks endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
 		junit                    : "5.10.1",
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
-		cri_common_lib           : "5.0.2",
+		cri_common_lib           : "6.1.0",
 		webcompere_version       : "2.1.7",
 	]
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Bumped cri-lib -> 6.1.0 to include JWKS endpoint being retrieved from SSM to support multiple clients.

### Why did it change

The CRIs need to consume the public signing key from the service that signed the JWT.

### Issue tracking

- [OJ-3175](https://govukverify.atlassian.net/browse/OJ-3175)


[OJ-3175]: https://govukverify.atlassian.net/browse/OJ-3175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ