### PR TITLE
OJ-3166: Enable Address Int and Prod consume public JWK

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -167,8 +167,8 @@ Mappings:
       dev: true
       build: true
       staging: true
-      integration: false
-      production: false
+      integration: true
+      production: true
     di-ipv-cri-fraud-api:
       dev: false
       build: false


### PR DESCRIPTION
## Proposed changes

### What changed

Enable Address Integration and Prod to consume public JWK

### Why did it change

A One Login user must be able to continue their identity proving journey whilst a key rotation is taking place in IPV Core.

### Issue tracking

- [OJ-3166](https://govukverify.atlassian.net/browse/OJ-3166)
