### PR TITLE
OJ-3143: Enable using new encryption keys in build

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -283,7 +283,7 @@ Mappings:
   KeyRotationMapping:
     di-ipv-cri-address-api:
       dev: "true"
-      build: "false"
+      build: "true"
       staging: "false"
       integration: "false"
       production: "false"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

 Enable using new encryption keys in build

### Why did it change

We have the jwks endpoint deployed and the old core stub is using it 


### Screenshots

**Tested in dev**

Core stub used encryption keys from jwks endpoint
<img width="1446" alt="image" src="https://github.com/user-attachments/assets/c0e0e3c1-19d0-4483-b54a-d9cce762e8a7" />

Session lambda decrypted using KMS aliases
<img width="799" alt="image" src="https://github.com/user-attachments/assets/ae5f02c5-0008-49d3-8290-5eb5cbbd8b89" />
<img width="786" alt="image" src="https://github.com/user-attachments/assets/b0354712-a2d4-49b0-853d-9a7d949e449e" />


### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3143](https://govukverify.atlassian.net/browse/OJ-3143)



[OJ-3143]: https://govukverify.atlassian.net/browse/OJ-3143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ