### PR TITLE
LIME-1674 Add Legacy Key fall back to aid seemless live migration to key aliases

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -324,6 +324,51 @@ Mappings:
       integration: "false"
       production: "false"
 
+  # Enable fall back with key rotation aliases in session decryption
+  KeyRotationLegacyFallBackMapping:
+    di-ipv-cri-address-api:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+    di-ipv-cri-fraud-api:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+    di-ipv-cri-kbv-api:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+    di-ipv-cri-dl-api:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+    di-ipv-cri-passport-api:
+      dev: "true"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+    di-ipv-cri-kbv-hmrc-api:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+    di-ipv-cri-check-hmrc-api:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+
   # TS functions Only 0 = off
   TSProvisionedConcurrencyMapping:
     di-ipv-cri-address-api:
@@ -751,6 +796,7 @@ Resources:
             Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
           ENV_VAR_FEATURE_FLAG_KEY_ROTATION: !FindInMap [ KeyRotationMapping, !Ref CriIdentifier, !Ref Environment ]
           ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK: !FindInMap [ CorePublicSigningJwksEnabled, !Ref CriIdentifier, !Ref Environment ]
+          ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK: !FindInMap [ KeyRotationLegacyFallBackMapping, !Ref CriIdentifier, !Ref Environment ]
       AutoPublishAlias: live
       AutoPublishAliasAllProperties: true
       SnapStart:

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/KMSRSADecrypterTest.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/KMSRSADecrypterTest.java
@@ -56,6 +56,7 @@ class KMSRSADecrypterTest {
     @BeforeEach
     void setup() {
         environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "false");
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "false");
     }
 
     @Test
@@ -238,8 +239,11 @@ class KMSRSADecrypterTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenAllKeyAliasesAreNotPresent() throws Exception {
+    void shouldThrowExceptionWhenAllKeyAliasesAreNotPresentAndLegacyKeyFallBackIsNotEnabled()
+            throws Exception {
         environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "false");
+
         KMSRSADecrypter kmsRsaDecrypter =
                 new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
         JWEHeader header = createHeader();
@@ -262,6 +266,96 @@ class KMSRSADecrypterTest {
                                 header, encryptedKey, iv, cipherText, authTag, AAD.compute(header)),
                 "Failed to decrypt with all available key aliases.");
         verify(mockKmsClient, times(3)).decrypt(any(DecryptRequest.class));
+        verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
+    }
+
+    @Test
+    void
+            shouldThrowExceptionWhenAllKeyAliasesAreNotPresentAndLegacyKeyFallBackIsEnabledAndLegacyKeyFallBackFails()
+                    throws Exception {
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
+
+        KMSRSADecrypter kmsRsaDecrypter =
+                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
+        JWEHeader header = createHeader();
+        Base64URL encryptedKey =
+                Base64URL.from(
+                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+        Base64URL cipherText =
+                Base64URL.from(
+                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+        when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                .thenThrow(new RuntimeException("primary key failed to decrypt"))
+                .thenThrow(new RuntimeException("secondary key failed to decrypt"))
+                .thenThrow(new RuntimeException("previous key failed to decrypt"))
+                .thenThrow(new RuntimeException("Failed to decrypt with legacy key.")); // fallback
+
+        assertThrows(
+                JOSEException.class,
+                () ->
+                        kmsRsaDecrypter.decrypt(
+                                header, encryptedKey, iv, cipherText, authTag, AAD.compute(header)),
+                "Failed to decrypt with legacy key.");
+        verify(mockKmsClient, times(4)).decrypt(any(DecryptRequest.class));
+        verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
+    }
+
+    @Test
+    void
+            shouldDecryptWhenAllKeyAliasesAreNotPresentAndLegacyKeyFallBackIsEnabledAndLegacyKeyFallBackSucceeds()
+                    throws Exception {
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION", "true");
+        environmentVariables.set("ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK", "true");
+
+        KMSRSADecrypter kmsRsaDecrypter =
+                new KMSRSADecrypter(TEST_KEY_ID, this.mockKmsClient, this.mockeventProbe);
+        JWEHeader header = createHeader();
+        Base64URL encryptedKey =
+                Base64URL.from(
+                        "jfDZSCq6Z7Hu22uWaNEtDfFfv-RZot58oxhTAwNoGT3aMvWUiZBIzqm0b9f2xkxMBEky3oix9xC5_KRL2Xv-OO9DdTw7sfLMUs7BidEXWRIAq7PgiD1rdkQ5ElZHM1TPYoREXhJyqtXMgup8lD_B85m-xBOgaZQvuG_cxc0lNerLBgu1f23jcy0S8G3P8L-Cl056Kv6QV-WGFOQW0Vurwd_f432Ho1W1STYrSat22YNkX2_A0SJZGVcxF_wKKfNAUw4n7sVdYZOfl62x7Cz2Rt2HX36U6vLhI8ZLNGROCsNKI-LYJA2ET1_li150DMgMNlfYfwHrO3jFi_j1XcK_oA");
+        Base64URL iv = Base64URL.from("esSJbN3jlduupMFy");
+        Base64URL cipherText =
+                Base64URL.from(
+                        "cT7gnhBT0VT7jY5gEAsafuZi-o6BP8DI-aaH97mJ4e6q0E1pAgWkWAHc-qvmRWYHLUfbMlTOpH5AlQNhQ-ZWsfm40eM0sIV3OZCk4KcAbSoz4v-9aqleBTVhr_YhZqk_lZ9I9566SzLnOuPkWQr6J5F6F19Ol7Ob0j7-a2zHgXlxQizp1hjXiWAhJ0aFFRfP4hxcohn7h5EKeMw8ZT8jv1kqc0PwRoZOt83SgBcdlLcIz9LDPIUWuXXtw9Xi5FrfAc2SXFv4sv7BEo70-ICT9sC1jTpkMsqJlofqu5R3L2Kf51HFOJe2C1SRy_MQGID9FnQGgrDburfSpcmH_DPxdLS8SJ9X7LyyrPWzrdTwgUDdUCWmsoYbvgZQC1KhRiu7GjKLDU2uQgo0NSiaNIcyS6qllDXPqJUTkz0snmMUjcIN7ZTzA29ngxJh5OhI444qChQrB-2hU769giX00UEyqb--MpTWybGReoC0nF-BzaZrrQkWMB2vFWiDg5dUUD6778b4YvmryINCP5H4NteK8JHnIsqMMbY6wxtZFqVhsvVAR6thM9JBKJrN5nSMkKlwSAEpf2vbUyec2x_AZQ6d66lrneZe3VHWmHAo42d6if2P-yaL2vLrr9g73vr7CfU9WiTYTYtFOJ0aWodFwnSeZq-Bek1RXTNsEl4G8K3ved97W1YlEW4359V6OWpSCfFouDJv-yLxaedRvzXjcBH0Ssx6D8Njs4cOduQ-PE22mUcpHd5URsUsU19F59jgXpk");
+        Base64URL authTag = Base64URL.from("I48OP5ZO-bl9nqunO4VX6w");
+        DecryptResponse decryptResponse =
+                DecryptResponse.builder()
+                        .plaintext(
+                                SdkBytes.fromByteArray(
+                                        Base64.getDecoder()
+                                                .decode(
+                                                        "ngoABokVaj3BYY8FfaPef4nzV9dr+ziueibf2hofYDQ=")))
+                        .build();
+
+        when(mockKmsClient.decrypt(any(DecryptRequest.class)))
+                .thenThrow(new RuntimeException("primary key failed to decrypt"))
+                .thenThrow(new RuntimeException("secondary key failed to decrypt"))
+                .thenThrow(new RuntimeException("previous key failed to decrypt"))
+                .thenReturn(decryptResponse); // legacy fallback
+
+        byte[] result =
+                kmsRsaDecrypter.decrypt(
+                        header, encryptedKey, iv, cipherText, authTag, AAD.compute(header));
+        SignedJWT signedJWT = SignedJWT.parse(new String(result, StandardCharsets.UTF_8));
+        JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+        ArgumentCaptor<DecryptRequest> decryptRequestArgumentCaptor =
+                ArgumentCaptor.forClass(DecryptRequest.class);
+        verify(mockKmsClient, times(4)).decrypt(decryptRequestArgumentCaptor.capture());
+        DecryptRequest actualDecryptRequest = decryptRequestArgumentCaptor.getValue();
+        assertEquals(
+                EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256.toString(),
+                actualDecryptRequest.encryptionAlgorithmAsString());
+        assertEquals("test-key", actualDecryptRequest.keyId());
+        assertArrayEquals(
+                encryptedKey.decode(), actualDecryptRequest.ciphertextBlob().asByteArray());
+        assertEquals(11, claims.getClaims().size());
+        assertEquals("urn:uuid:8d097496-4410-49db-acdb-ffdca993fd2f", claims.getSubject());
+        assertEquals("ipv-core-stub", claims.getIssuer());
+
+        verify(mockKmsClient, times(4)).decrypt(any(DecryptRequest.class));
         verify(mockeventProbe, times(1)).counterMetric(ALL_ALIASES_UNAVAILABLE);
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add Legacy Key fall back to key rotation enable code path

### Why did it change

To aid seemless live migration to key aliases when the existing key may still be in use

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1674](https://govukverify.atlassian.net/browse/LIME-1674)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1674]: https://govukverify.atlassian.net/browse/LIME-1674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ