### PR TITLE
OJ-3176 - Retrieve JWKS endpoint from SSM parameter store rather than using env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,36 @@ with the value set to true i.e. FRAUD_DEV_ENABLED KBV_BUILD_ENABLED
 **important:** One you've cloned the repo, run `pre-commit install` to install the pre-commit hooks.
 If you have not installed `pre-commit` then please do so [here](https://pre-commit.com/).
 
+## Authorising with GitHub Packages
+
+Some of the Node modules used in this repository are private modules stored in the One Login GitHub Packages repository. NPM therefore needs credentials in order to access the packages as you.
+
+This can be done as follows:
+
+### Step 1: Create a GitHub Personal Access Token.
+
+GitHub has a guide on this [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
+
+Currently (05-2025), this requires a 'classic' personal access token (see [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-to-github-packages)). Quick testing indicates that you need to select at least the `read:packages` scope.
+
+### Step 2: Pass the token into NPM, via an .npmrc file in the root of the repository.
+
+It should look like the following:
+
+```
+//npm.pkg.github.com/:_authToken=${NPM_GITHUB_PACKAGES_TOKEN}
+```
+
+You can enter the auth token directly where `${NPM_GITHUB_PACKAGES_TOKEN}` is written, as .npmrc is in the .gitignore, but this is not recommended as it risks accidentally leaking your personal access token if .gitignore is changed.
+
+The recommended method is to export an environment variable with your token. You can do this by editing `~/.zprofile` if using zsh (macOS default terminal), or `~/.bashrc` for bash (the most common Linux terminal). Just add the following to the bottom:
+
+```sh
+export NPM_GITHUB_PACKAGES_TOKEN=ghp_mytokenblahblah
+```
+
+After restarting your terminal, the new environment variable should be set and NPM should be able to pull from GitHub Packages using the .npmrc definition.
+
 ## Run Cucumber tests
 
 Below runs and uses the core stub, with the following defaults:
@@ -76,9 +106,7 @@ NOTE: Since this is defaulting `CRI_DEV=common-lambda-dev`
 and contains keys configured for the common lambda account `di-ipv-cri-common-dev`the `API_GATEWAY_ID_PRIVATE` can be found
 in the output of the common lambda stack being targeted i.e the value of `PreMergeDevOnlyApiId` output.
 
-`
-STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber
-`
+`STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber`
 
 Run in KBV CRI specify `CRI_DEV=kbv-cri-dev` allows the command below to use keys in `ipv-config` pointing to keys in `di-ipv-cri-kbv-dev` for a common lambda stack deploy in that account.
 
@@ -86,7 +114,7 @@ Run in KBV CRI specify `CRI_DEV=kbv-cri-dev` allows the command below to use key
 
 Run in ADDRESS CRI specify `CRI_DEV=address-cri-dev` allow the command below to use keys in `ipv-config` pointing to keys in `di-ipv-cri-address-dev` for a common lambda stack deploy in that account.
 
-`CRI_DEV=address-cri-dev STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber   
+`CRI_DEV=address-cri-dev STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber
 
 You can run against localhost as follows:
 

--- a/README.md
+++ b/README.md
@@ -91,13 +91,15 @@ NOTE: Since this is defaulting `CRI_DEV=common-lambda-dev`
 and contains keys configured for the common lambda account `di-ipv-cri-common-dev`the `API_GATEWAY_ID_PRIVATE` can be found
 in the output of the common lambda stack being targeted i.e the value of `PreMergeDevOnlyApiId` output.
 
-`
+```sh
+STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.stubs.account.gov.uk" gradle integration-tests:cucumber`
+```
 
-`STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.stubs.account.gov.uk" gradle integration-tests:cucumber
+Below runs overriding default stub by using the AWS stub`
 
-`Below runs overriding default stub by using the AWS stub`
+```sh
 STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" DEFAULT_CLIENT_ID=ipv-core-stub-aws-prod gradle integration-tests:cucumber
-`
+```
 
 You can run against localhost as follows:
 
@@ -106,21 +108,27 @@ NOTE: Since this is defaulting `CRI_DEV=common-lambda-dev`
 and contains keys configured for the common lambda account `di-ipv-cri-common-dev`the `API_GATEWAY_ID_PRIVATE` can be found
 in the output of the common lambda stack being targeted i.e the value of `PreMergeDevOnlyApiId` output.
 
-`STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber`
+```sh
+STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber
+```
 
 Run in KBV CRI specify `CRI_DEV=kbv-cri-dev` allows the command below to use keys in `ipv-config` pointing to keys in `di-ipv-cri-kbv-dev` for a common lambda stack deploy in that account.
 
-`CRI_DEV=kbv-cri-dev STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber
+```sh
+CRI_DEV=kbv-cri-dev STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber
+```
 
 Run in ADDRESS CRI specify `CRI_DEV=address-cri-dev` allow the command below to use keys in `ipv-config` pointing to keys in `di-ipv-cri-address-dev` for a common lambda stack deploy in that account.
 
-`CRI_DEV=address-cri-dev STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber
+```sh
+CRI_DEV=address-cri-dev STACK_NAME=di-ipv-cri-common-api-your-stack-name ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" gradle integration-tests:cucumber
+```
 
 You can run against localhost as follows:
 
-`STACK_NAME=di-ipv-cri-common-api-your-stack-name CRI_DEV=kbv-cri-dev ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="http://localhost:8085" gradle integration-tests:cucumber
-
-`
+```sh
+STACK_NAME=di-ipv-cri-common-api-your-stack-name CRI_DEV=kbv-cri-dev ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="http://localhost:8085" gradle integration-tests:cucumber
+```
 
 NOTE: The common-lambda stack has an extra `/pre-merge-create-auth-code` endpoint which it uses to create an authorization code which it needs as prerequisite to test certain paths, since it is not a CRI itself (since it just a collection of common endpoints used by CRI's).
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The recommended method is to export an environment variable with your token. You
 export NPM_GITHUB_PACKAGES_TOKEN=ghp_mytokenblahblah
 ```
 
-After restarting your terminal, the new environment variable should be set and NPM should be able to pull from GitHub Packages using the .npmrc definition.
+After restarting your terminal, the new environment variable should be set and NPM should be able to pull from GitHub Packages using the .npmrc definition. You can also copy the same .npmrc content to any other repositories that need access to GitHub Packages, as the environment variable will be set globally for all terminals you launch in your account.
 
 ## Run Cucumber tests
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -852,7 +852,6 @@ Resources:
             Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
           CRI_IDENTIFIER: !Sub "${CriIdentifier}"
           ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK: !FindInMap [ KeyRotationEnabled, !Ref CriIdentifier, !Ref Environment]
-          PUBLIC_JWKS_ENDPOINT: !FindInMap [ JwkEndpoint, !Ref CriIdentifier, !Ref Environment ]
       AutoPublishAlias: live
       AutoPublishAliasAllProperties: true
       Policies:
@@ -1159,7 +1158,6 @@ Resources:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-access-token-2"
           ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK: !FindInMap [ KeyRotationEnabled, !Ref CriIdentifier, !Ref Environment]
-          PUBLIC_JWKS_ENDPOINT: !FindInMap [ JwkEndpoint, !Ref CriIdentifier, !Ref Environment ]
       AutoPublishAlias: live
       AutoPublishAliasAllProperties: true
       Policies:

--- a/lambdas/src/common/security/jwt-verifier.ts
+++ b/lambdas/src/common/security/jwt-verifier.ts
@@ -30,7 +30,7 @@ export class JwtVerifier {
         private logger: Logger,
     ) {
         this.usePublicJwksEndpoint = process.env.ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK ?? "false";
-        this.jwksEndpoint = jwtVerifierConfig.jwksEndpoint;
+        this.jwksEndpoint = jwtVerifierConfig.jwksEndpoint ?? "";
     }
 
     public async verify(

--- a/lambdas/src/handlers/access-token-handler.ts
+++ b/lambdas/src/handlers/access-token-handler.ts
@@ -127,6 +127,7 @@ export const lambdaHandler = middy(handlerClass.handler.bind(handlerClass))
                 ClientConfigKey.JWT_PUBLIC_SIGNING_KEY,
                 ClientConfigKey.JWT_REDIRECT_URI,
                 ClientConfigKey.JWT_SIGNING_ALGORITHM,
+                ClientConfigKey.JWKS_ENDPOINT,
             ],
         }),
     )

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -181,6 +181,7 @@ export const lambdaHandler = middy(handlerClass.handler.bind(handlerClass))
                 ClientConfigKey.JWT_PUBLIC_SIGNING_KEY,
                 ClientConfigKey.JWT_REDIRECT_URI,
                 ClientConfigKey.JWT_SIGNING_ALGORITHM,
+                ClientConfigKey.JWKS_ENDPOINT,
             ],
             client_absolute_paths: [{ prefix: criIdentifier, suffix: ConfigKey.CRI_EVIDENCE_PROPERTIES }],
         }),

--- a/lambdas/src/services/session-request-validator.ts
+++ b/lambdas/src/services/session-request-validator.ts
@@ -114,6 +114,7 @@ export class SessionRequestValidatorFactory {
                 {
                     jwtSigningAlgorithm: criClientConfig.get(ClientConfigKey.JWT_SIGNING_ALGORITHM) as string,
                     publicSigningJwk: criClientConfig.get(ClientConfigKey.JWT_PUBLIC_SIGNING_KEY) as string,
+                    jwksEndpoint: criClientConfig.get(ClientConfigKey.JWKS_ENDPOINT) as string,
                 },
                 this.logger,
             ),

--- a/lambdas/src/services/token-request-validator.ts
+++ b/lambdas/src/services/token-request-validator.ts
@@ -48,6 +48,7 @@ export class AccessTokenRequestValidator {
         const jwtVerifier = this.jwtVerifierFactory.create(
             clientConfig.get(ClientConfigKey.JWT_SIGNING_ALGORITHM) as string,
             clientConfig.get(ClientConfigKey.JWT_PUBLIC_SIGNING_KEY) as string,
+            clientConfig.get(ClientConfigKey.JWKS_ENDPOINT) as string,
         );
 
         const jwtPayload = await jwtVerifier.verify(

--- a/lambdas/src/types/config-keys.ts
+++ b/lambdas/src/types/config-keys.ts
@@ -12,6 +12,7 @@ export enum ClientConfigKey {
     JWT_PUBLIC_SIGNING_KEY = "publicSigningJwkBase64",
     JWT_REDIRECT_URI = "redirectUri",
     JWT_SIGNING_ALGORITHM = "authenticationAlg",
+    JWKS_ENDPOINT = "jwksEndpoint",
 }
 
 export enum ConfigKey {

--- a/lambdas/src/types/jwt-verification-config.ts
+++ b/lambdas/src/types/jwt-verification-config.ts
@@ -1,4 +1,5 @@
 export interface JwtVerificationConfig {
     publicSigningJwk: string;
     jwtSigningAlgorithm: string;
+    jwksEndpoint: string;
 }

--- a/lambdas/tests/unit/common/security/jwt-verifier.test.ts
+++ b/lambdas/tests/unit/common/security/jwt-verifier.test.ts
@@ -39,6 +39,7 @@ describe("jwt-verifier.ts", () => {
                 jwtVerifierConfig = {
                     publicSigningJwk: "publicSigningJwk",
                     jwtSigningAlgorithm: "ES256",
+                    jwksEndpoint: "http://localhost",
                 };
                 jwtVerifyOptions = {
                     algorithms: ["ES256"],
@@ -81,7 +82,6 @@ describe("jwt-verifier.ts", () => {
                 beforeEach(() => {
                     global.fetch = jest.fn();
                     process.env.ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK = "true";
-                    process.env.PUBLIC_JWKS_ENDPOINT = "http://localhost";
                     jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as Logger);
                     jwtVerifyMock.mockResolvedValue({
                         payload: MOCK_JWT,
@@ -590,7 +590,11 @@ describe("jwt-verifier.ts", () => {
         });
 
         it("should create a session request validator", () => {
-            const output = jwtVerifierFactory.create("test-signing-algo", "test-public-signing-key");
+            const output = jwtVerifierFactory.create(
+                "test-signing-algo",
+                "test-public-signing-key",
+                "http://localhost",
+            );
             expect(output).toBeInstanceOf(JwtVerifier);
         });
     });

--- a/lambdas/tests/unit/common/security/jwt-verifier.test.ts
+++ b/lambdas/tests/unit/common/security/jwt-verifier.test.ts
@@ -172,10 +172,9 @@ describe("jwt-verifier.ts", () => {
                 });
 
                 describe("JWKS Endpoint fail and fallback", () => {
-                    it("should use fallback method when PUBLIC_JWKS_ENDPOINT is not set", async () => {
-                        process.env.PUBLIC_JWKS_ENDPOINT = "";
+                    it("should use fallback method when jwksEndpoint is not set", async () => {
+                        jwtVerifier = new JwtVerifier({ ...jwtVerifierConfig, jwksEndpoint: "" }, logger as Logger);
 
-                        jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as Logger);
                         // @ts-expect-error: Private function
                         const fallbackSpy = jest.spyOn(jwtVerifier, "verifyWithJwksParam").mockImplementation(() => {
                             return {
@@ -195,10 +194,12 @@ describe("jwt-verifier.ts", () => {
                         });
                     });
 
-                    it("should use fallback method when PUBLIC_JWKS_ENDPOINT is not a valid url", async () => {
-                        process.env.PUBLIC_JWKS_ENDPOINT = "localhost";
+                    it("should use fallback method when jwksEndpoint is not a valid url", async () => {
+                        jwtVerifier = new JwtVerifier(
+                            { ...jwtVerifierConfig, jwksEndpoint: "localhost" },
+                            logger as Logger,
+                        );
 
-                        jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as Logger);
                         // @ts-expect-error: Private function
                         const fallbackSpy = jest.spyOn(jwtVerifier, "verifyWithJwksParam").mockImplementation(() => {
                             return {
@@ -280,7 +281,6 @@ describe("jwt-verifier.ts", () => {
                     } as unknown as Logger;
                     publicKey = new Uint8Array([3, 101, 120, 26, 14, 184, 5, 99, 172, 149]);
                     process.env.ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK = "false";
-                    process.env.PUBLIC_JWKS_ENDPOINT = undefined;
                     jwtVerifier = new JwtVerifier(jwtVerifierConfig, logger as Logger);
                     signingPublicJwk = {
                         alg: "ES256",

--- a/lambdas/tests/unit/handlers/access-token-handler.test.ts
+++ b/lambdas/tests/unit/handlers/access-token-handler.test.ts
@@ -108,6 +108,7 @@ describe("access-token-handler.ts", () => {
         const jwtVerificationConfig: JwtVerificationConfig = {
             publicSigningJwk: "",
             jwtSigningAlgorithm: "",
+            jwksEndpoint: "",
         };
         let jwtVerifier: JwtVerifier;
         let mockMetrics: jest.MockedObjectDeep<typeof Metrics>;

--- a/lambdas/tests/unit/handlers/contract/routes/access-token-factory.ts
+++ b/lambdas/tests/unit/handlers/contract/routes/access-token-factory.ts
@@ -13,7 +13,8 @@ import { MockDynamoDBDocument } from "../mocks/mock-dynamo-db-document";
 import { ClientConfigKey, CommonConfigKey } from "../../../../../src/types/config-keys";
 
 const parameterPathPrefix = process.env.AWS_STACK_NAME || "";
-const { JWT_AUDIENCE, JWT_PUBLIC_SIGNING_KEY, JWT_REDIRECT_URI, JWT_SIGNING_ALGORITHM } = ClientConfigKey;
+const { JWT_AUDIENCE, JWT_PUBLIC_SIGNING_KEY, JWT_REDIRECT_URI, JWT_SIGNING_ALGORITHM, JWKS_ENDPOINT } =
+    ClientConfigKey;
 const { SESSION_TABLE_NAME, SESSION_TTL } = CommonConfigKey;
 
 export const CreateAccessTokenLambda = (redirectUri: string, componentId: string) => {
@@ -40,6 +41,8 @@ export const CreateAccessTokenLambda = (redirectUri: string, componentId: string
             [`/${parameterPathPrefix}/clients/ipv-core/jwtAuthentication/${JWT_REDIRECT_URI}`]: redirectUri,
             [`/${parameterPathPrefix}/clients/ipv-core/jwtAuthentication/${JWT_AUDIENCE}`]: componentId,
             [`/${parameterPathPrefix}/clients/ipv-core/jwtAuthentication/${JWT_PUBLIC_SIGNING_KEY}`]: "mock_public_key",
+            [`/${parameterPathPrefix}/clients/ipv-core/jwtAuthentication/${JWT_PUBLIC_SIGNING_KEY}`]: "mock_public_key",
+            [`/${parameterPathPrefix}/clients/ipv-core/jwtAuthentication/${JWKS_ENDPOINT}`]: "mock_public_key",
         }) as unknown as SSMProvider,
     );
 

--- a/lambdas/tests/unit/handlers/contract/routes/access-token-router.ts
+++ b/lambdas/tests/unit/handlers/contract/routes/access-token-router.ts
@@ -17,7 +17,8 @@ import { AccessTokenLambda } from "../../../../../src/handlers/access-token-hand
 import { AuthRequest } from "../utils/incoming-request-converters";
 import { CreateAccessTokenLambda } from "./access-token-factory";
 
-const { JWT_AUDIENCE, JWT_PUBLIC_SIGNING_KEY, JWT_REDIRECT_URI, JWT_SIGNING_ALGORITHM } = ClientConfigKey;
+const { JWT_AUDIENCE, JWT_PUBLIC_SIGNING_KEY, JWT_REDIRECT_URI, JWT_SIGNING_ALGORITHM, JWKS_ENDPOINT } =
+    ClientConfigKey;
 const { SESSION_TABLE_NAME, SESSION_TTL } = CommonConfigKey;
 
 class AccessTokenRouter {
@@ -72,7 +73,13 @@ class AccessTokenRouter {
             .use(
                 initialiseClientConfigMiddleware({
                     configService: lambda.getConfigService(),
-                    client_config_keys: [JWT_AUDIENCE, JWT_PUBLIC_SIGNING_KEY, JWT_REDIRECT_URI, JWT_SIGNING_ALGORITHM],
+                    client_config_keys: [
+                        JWT_AUDIENCE,
+                        JWT_PUBLIC_SIGNING_KEY,
+                        JWT_REDIRECT_URI,
+                        JWT_SIGNING_ALGORITHM,
+                        JWKS_ENDPOINT,
+                    ],
                 }),
             )
             .use(getSessionByIdMiddleware({ sessionService: lambda.getSessionService() }))

--- a/lambdas/tests/unit/handlers/session-handler.test.ts
+++ b/lambdas/tests/unit/handlers/session-handler.test.ts
@@ -162,6 +162,7 @@ describe("SessionLambda", () => {
                         ClientConfigKey.JWT_PUBLIC_SIGNING_KEY,
                         ClientConfigKey.JWT_REDIRECT_URI,
                         ClientConfigKey.JWT_SIGNING_ALGORITHM,
+                        ClientConfigKey.JWKS_ENDPOINT,
                     ],
                 }),
             )
@@ -237,6 +238,7 @@ describe("SessionLambda", () => {
             ClientConfigKey.JWT_PUBLIC_SIGNING_KEY,
             ClientConfigKey.JWT_REDIRECT_URI,
             ClientConfigKey.JWT_SIGNING_ALGORITHM,
+            ClientConfigKey.JWKS_ENDPOINT,
         ]);
     });
 
@@ -479,6 +481,7 @@ describe("SessionLambda", () => {
                             ClientConfigKey.JWT_PUBLIC_SIGNING_KEY,
                             ClientConfigKey.JWT_REDIRECT_URI,
                             ClientConfigKey.JWT_SIGNING_ALGORITHM,
+                            ClientConfigKey.JWKS_ENDPOINT,
                         ],
                         client_absolute_paths: [
                             { prefix: previousCriIdentifier, suffix: ConfigKey.CRI_EVIDENCE_PROPERTIES },
@@ -734,6 +737,7 @@ describe("SessionLambda", () => {
                             ClientConfigKey.JWT_ISSUER,
                             ClientConfigKey.JWT_PUBLIC_SIGNING_KEY,
                             ClientConfigKey.JWT_REDIRECT_URI,
+                            ClientConfigKey.JWKS_ENDPOINT,
                             ClientConfigKey.JWT_SIGNING_ALGORITHM,
                         ],
                         client_absolute_paths: [


### PR DESCRIPTION
## Proposed changes

### What changed

- JwtVerifier now expects a new `jwksEndpoint` key in the `jwtVerifierConfig` object passed to its constructor
  - This is used in place of the PUBLIC_JWKS_ENDPOINT environment variable, which can now be safely retired
- Updated ConfigService & ClientConfigKeys enum to support the `jwksEndpoint` SSM param
- Updated middleware registrations to tell ConfigService to retrieve `jwksEndpoint`
- Updated unit tests where they referred to PUBLIC_JWKS_ENDPOINT

### Why did it change

We are moving to SSM parameters for this config option as it gives us the flexibility to set the JWKS endpoint on a per-CRI / per-environment / per-stack basis.

### Issue tracking

OJ-3176

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [x] Documented in the [README](./blob/main/README.md)
- [x] Added to deployment repository
- [x] Added to local startup repository

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
