### PR TITLE
OJ-3078: Enable CorePublicSigningJwksEnabled for check-hmrc upto staging

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -200,9 +200,9 @@ Mappings:
       integration: false
       production: false
     di-ipv-cri-check-hmrc-api:
-      dev: false
-      build: false
-      staging: false
+      dev: true
+      build: true
+      staging: true
       integration: false
       production: false
 


### PR DESCRIPTION
## Proposed changes

### What changed

Enable `CorePublicSigningJwksEnabled` for check-hmrc for dev, build & staging

### Why did it change

A One Login user must be able to continue their identity proving journey whilst a key rotation is taking place in IPV Core.

### Issue tracking

- [OJ-3078](https://govukverify.atlassian.net/browse/OJ-3078)


[OJ-3078]: https://govukverify.atlassian.net/browse/OJ-3078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ