### PR TITLE
OJ-3173 - Set CorePublicSigningJwksEnabled=true for KBV prod+int

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -179,8 +179,8 @@ Mappings:
       dev: true
       build: true
       staging: true
-      integration: false
-      production: false
+      integration: true
+      production: true
     di-ipv-cri-dl-api:
       dev: false
       build: false


### PR DESCRIPTION
## Proposed changes

### What changed

Switched on consumption of the core JWKS endpoint in KBV integration + production.

### Why did it change

We want to ensure an unbroken user journey while signing keys are rotated.

### Issue tracking

OJ-3173

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
