### PR TITLE
OJ-3172: Enable check-hmrc to consume core jwks endpoint in int and prod

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -203,8 +203,8 @@ Mappings:
       dev: true
       build: true
       staging: true
-      integration: false
-      production: false
+      integration: true
+      production: true
 
   CoreJwksEndpoint:
     Environment:


### PR DESCRIPTION
## Proposed changes

### What changed

Enable `CorePublicSigningJwksEnabled` for check-hmrc int and prod.

### Why did it change

A One Login user must be able to continue their identity proving journey whilst a key rotation is taking place in IPV Core.

### Issue tracking

- [OJ-3172](https://govukverify.atlassian.net/browse/OJ-3172)

### Checks

No issues seen in check-hmrc dev, build or staging.
No issues seen in experian-kbv prod. 

[OJ-3172]: https://govukverify.atlassian.net/browse/OJ-3172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ