### PR TITLE
LIME-1693 Mapped evidence requested in session request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
 		junit                    : "5.10.1",
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
-		cri_common_lib           : "6.2.2",
+		cri_common_lib           : "6.3.0",
 		webcompere_version       : "2.1.7",
 	]
 }

--- a/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestService.java
+++ b/session/src/main/java/uk/gov/di/ipv/cri/common/api/service/SessionRequestService.java
@@ -14,6 +14,7 @@ import uk.gov.di.ipv.cri.common.library.domain.SessionRequest;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.SharedClaims;
 import uk.gov.di.ipv.cri.common.library.exception.ClientConfigurationException;
 import uk.gov.di.ipv.cri.common.library.exception.SessionValidationException;
+import uk.gov.di.ipv.cri.common.library.persistence.item.EvidenceRequest;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.JWTVerifier;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
@@ -26,12 +27,14 @@ import java.util.Map;
 import java.util.Objects;
 
 public class SessionRequestService {
+
     private static final String SHARED_CLAIMS_NAME = "shared_claims";
     private static final String REDIRECT_URI = "redirect_uri";
     private static final String CLIENT_ID = "client_id";
     private static final String PERSISTENT_SESSION_ID = "persistent_session_id";
     private static final String CLIENT_SESSION_ID = "govuk_signin_journey_id";
     private static final String CONTEXT = "context";
+    private static final String EVIDENCE_REQUEST = "evidence_requested";
 
     private final ObjectMapper objectMapper;
     private final JWTVerifier jwtVerifier;
@@ -136,6 +139,15 @@ public class SessionRequestService {
 
             if (jwtClaims.getClaims().containsKey(CONTEXT)) {
                 sessionRequest.setContext(jwtClaims.getStringClaim(CONTEXT));
+            }
+
+            if (jwtClaims.getClaims().containsKey(EVIDENCE_REQUEST)) {
+                EvidenceRequest evidenceRequest =
+                        this.objectMapper.readValue(
+                                objectMapper.writeValueAsString(
+                                        jwtClaims.getClaim(EVIDENCE_REQUEST)),
+                                EvidenceRequest.class);
+                sessionRequest.setEvidenceRequest(evidenceRequest);
             }
 
             return sessionRequest;

--- a/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SignedJWTBuilder.java
+++ b/session/src/test/java/uk/gov/di/ipv/cri/common/api/service/SignedJWTBuilder.java
@@ -50,6 +50,7 @@ class SignedJWTBuilder {
     private String persistentSessionId = "persistentSessionIdTest";
     private String clientSessionId = "clientSessionIdTest";
     private Map<String, Object> sharedClaims = null;
+    private Map<String, Object> evidenceRequestedClaims = null;
     private String context;
 
     SignedJWTBuilder setNow(Instant now) {
@@ -112,6 +113,11 @@ class SignedJWTBuilder {
         return this;
     }
 
+    SignedJWTBuilder setEvidenceRequestedClaims(Map<String, Object> evidenceRequestedClaims) {
+        this.evidenceRequestedClaims = evidenceRequestedClaims;
+        return this;
+    }
+
     SignedJWTBuilder setPersistentSessionId(String persistentSessionId) {
         this.persistentSessionId = persistentSessionId;
         return this;
@@ -168,6 +174,10 @@ class SignedJWTBuilder {
                 if (Objects.nonNull(sharedClaims)) {
                     jwtClaimSetBuilder.claim("shared_claims", this.sharedClaims);
                 }
+            }
+
+            if (Objects.nonNull(evidenceRequestedClaims)) {
+                jwtClaimSetBuilder.claim("evidence_requested", evidenceRequestedClaims);
             }
 
             if (!StringUtils.isEmpty(context)) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated Java Common Session lambda to correctly map the evidence_requested field from the shared claims to the EvidenceRequest object within the SessionRequest. 

### Why did it change

Allows Fraud CRI to handle each permutation of the evidence_requested claim

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1693](https://govukverify.atlassian.net/browse/LIME-1693)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed



[LIME-1693]: https://govukverify.atlassian.net/browse/LIME-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ