### PR TITLE
LIME-1660 feature flag enabled to test Core/Stub JWKS endpoint in passport dev

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -188,7 +188,7 @@ Mappings:
       integration: false
       production: false
     di-ipv-cri-passport-api:
-      dev: false
+      dev: true
       build: false
       staging: false
       integration: false


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK feature flag switched on in dev so that the Core stub can be deployed and tested. feature flag will need to be turned back off in Dev once the change is pushed to higher envs to re-enable other local Dev testing.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1660](https://govukverify.atlassian.net/browse/LIME-1660)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[LIME-1660]: https://govukverify.atlassian.net/browse/LIME-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ