### PR TITLE
OJ-3182: Experian KBV use encryption well-known jwks

### DIFF
--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -41,9 +41,9 @@ Mappings:
       integration: false
       production: false
     di-ipv-cri-kbv-api:
-      localdev: false
-      dev: false
-      build: false
+      localdev: true
+      dev: true
+      build: true
       staging: false
       integration: false
       production: false


### PR DESCRIPTION
## Proposed changes

Enabled the KeyRotationMapping so that Experian can use the headless core stub using the well-known to encrypt the JAR For Experian

### What changed

Added https://api.review-k.dev.account.gov.uk/.well-known/jwks.json

### Why did it change

well-known endpoints for Experian KBV CRI would enable better management of public encryption keys and facilitate key-rotation 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3182:](https://govukverify.atlassian.net/browse/OJ-3182)
