### PR TITLE
OJ-3185: Enable key rotation headless for Experian KBV

### DIFF
--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -41,9 +41,9 @@ Mappings:
       integration: false
       production: false
     di-ipv-cri-kbv-api:
-      localdev: false
-      dev: false
-      build: false
+      localdev: true
+      dev: true
+      build: true
       staging: false
       integration: false
       production: false


### PR DESCRIPTION
## Proposed changes

Enable Key rotation for up to build environment for headless core stub so requests made by the start handler in those environments use encryption key from  `./well-known/jwks.json` to make JAR request

### What changed

We've enabled Key rotation for Experian KBV up to build we also need to enabled key rotation for request made by the start handler in those environments

### Why did it change

Part of effectively managing keys i.e. to enable easier rotation of keys used by CRI clients such as core to make requests to CRI

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3185:(https://govukverify.atlassian.net/browse/OJ-3185)
