### PR TITLE
LIME-1742 Feature flag enabled to test Core/Stub JWKS endpoint in driving licence dev

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -189,7 +189,7 @@ Mappings:
       integration: true
       production: true
     di-ipv-cri-dl-api:
-      dev: false
+      dev: true
       build: false
       staging: false
       integration: false


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

### What changed

ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK feature flag switched on in dev so that journeys using the Core stub can be tested.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1742](https://govukverify.atlassian.net/browse/LIME-1742)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1742]: https://govukverify.atlassian.net/browse/LIME-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ