### PR TITLE
LIME-1729: Turning on feature flag for ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK for fraud dev

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -177,7 +177,7 @@ Mappings:
       integration: true
       production: true
     di-ipv-cri-fraud-api:
-      dev: false
+      dev: true
       build: false
       staging: false
       integration: false


### PR DESCRIPTION
## Proposed changes

### What changed

Setting ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK to true.

### Why did it change

Testing the Core-Stub JWKS Endpoint in dev.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1729](https://govukverify.atlassian.net/browse/LIME-1729)



[LIME-1729]: https://govukverify.atlassian.net/browse/LIME-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ