### PR TITLE
LIME-1729: Feature flag enabled to test Core/Stub JWKS endpoint in Fr…

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -178,7 +178,7 @@ Mappings:
       production: true
     di-ipv-cri-fraud-api:
       dev: true
-      build: false
+      build: true
       staging: false
       integration: false
       production: false


### PR DESCRIPTION
### What changed

ENV_VAR_FEATURE_CONSUME_PUBLIC_JWK feature flag switched on in Build for testing.

### Why did it change

Testing the Core/Stub JWKS Endpoint in Build.

### Issue tracking
- [LIME-1729](https://govukverify.atlassian.net/browse/LIME-1729)


[LIME-1729]: https://govukverify.atlassian.net/browse/LIME-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ