### PR TITLE
LIME-1774 update canaryDeploymentapigatewayMappings for Lime services

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -780,14 +780,14 @@ Mappings:
       privateapigwname: "kbv-hmrc-cri-api-PrivateApiGatewayId-placehonder"
       publicapigwname: "kbv-hmrc-cri-api-PublicApiGatewayId-placehonder"
     di-ipv-cri-passport-api:
-      privateapigwname: "ipv-cri-passport-api-PrivateUKPassportAPIGatewayID-placehonder"
-      publicapigwname: "ipv-cri-passport-api-PublicUKPassportAPIGatewayID-placehonder"
+      privateapigwname: "ipv-cri-passport-api-PrivateUKPassportApi"
+      publicapigwname: "ipv-cri-passport-api-PublicUKPassportApi"
     di-ipv-cri-dl-api:
-      privateapigwname: "dl-cri-api-v1-PrivateDlApiGatewayId-placehonder"
-      publicapigwname: "dl-cri-api-v1-PublicDlApiGatewayId-placehonder"
+      privateapigwname: "dl-cri-api-v1-PrivateDLApi"
+      publicapigwname: "dl-cri-api-v1-PublicDLApi"
     di-ipv-cri-fraud-api:
-      privateapigwname: "fraud-cri-api-v1-PrivateFraudApiGatewayId-placehonder"
-      publicapigwname: "fraud-cri-api-v1-PublicFraudApiGatewayId-placehonder"
+      privateapigwname: "fraud-cri-api-v1-PrivateFraudApi"
+      publicapigwname: "fraud-cri-api-v1-PublicFraudApi"
 
 
 Resources:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update Lime service CanaryDeploymentapigatewayMappings to genuine api gateways. 
### Why did it change

To allow for common lambda canary rollout into Lime services (fraud, dl and passport). 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1774](https://govukverify.atlassian.net/browse/LIME-1774)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
