### PR TITLE
LIME-1727 Passport CRI (Integration) - Enable KeyRotationLegacyFallBackMapping and KeyRotationMapping

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -316,7 +316,7 @@ Mappings:
       dev: "true"
       build: "true"
       staging: "true"
-      integration: "false"
+      integration: "true"
       production: "false"
     di-ipv-cri-kbv-hmrc-api:
       dev: "false"
@@ -360,8 +360,8 @@ Mappings:
     di-ipv-cri-passport-api:
       dev: "false"
       build: "false"
-      staging: "true"
-      integration: "false"
+      staging: "false"
+      integration: "true"
       production: "false"
     di-ipv-cri-kbv-hmrc-api:
       dev: "false"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Passport CRI - Enable KeyRotationLegacyFallback and KeyRotation in Integration
Passport CRI - Disable KeyRotationLegacyFallback in Staging

### Why did it change

To enable key-rotations in integration

To remove the legacy fallback in staging now the rotation has taken place.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1727](https://govukverify.atlassian.net/browse/LIME-1727)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
