### PR TITLE
LIME-1727 Passport CRI (Production) - Enable KeyRotationLegacyFallBackMapping and KeyRotationMapping

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -317,7 +317,7 @@ Mappings:
       build: "true"
       staging: "true"
       integration: "true"
-      production: "false"
+      production: "true"
     di-ipv-cri-kbv-hmrc-api:
       dev: "false"
       build: "false"
@@ -361,8 +361,8 @@ Mappings:
       dev: "false"
       build: "false"
       staging: "false"
-      integration: "true"
-      production: "false"
+      integration: "false"
+      production: "true"
     di-ipv-cri-kbv-hmrc-api:
       dev: "false"
       build: "false"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Passport CRI - Enable KeyRotationLegacyFallback and KeyRotation in Production
Passport CRI - Disable KeyRotationLegacyFallback in Integration

### Why did it change

To enable key-rotations in Production

To remove the legacy fallback in Integration now the rotation has taken place.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1727](https://govukverify.atlassian.net/browse/LIME-1727)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1727]: https://govukverify.atlassian.net/browse/LIME-1727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
