### PR TITLE
LIME-1616 Passport integration/production Enable consuming CoreJwksEndpoint and turn of encryption key legacy fallback post key rotation in Passport production.

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -198,8 +198,8 @@ Mappings:
       dev: true
       build: true
       staging: true
-      integration: false
-      production: false
+      integration: true
+      production: true
     di-ipv-cri-kbv-hmrc-api:
       dev: false
       build: false
@@ -362,7 +362,7 @@ Mappings:
       build: "false"
       staging: "false"
       integration: "false"
-      production: "true"
+      production: "false"
     di-ipv-cri-kbv-hmrc-api:
       dev: "false"
       build: "false"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Passport integration/production Enable consuming CoreJwksEndpoint.

Turn of encryption key legacy fallback in Passport production.

### Why did it change

To enable consuming the ipv-core signing key.

To disable the acceptance of the legacy key, post encryption key rotation in Passport production.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1616](https://govukverify.atlassian.net/browse/LIME-1616)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1616]: https://govukverify.atlassian.net/browse/LIME-1616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ