### PR TITLE
LIME-1733 toggled KeyRotation and LegacyKey flags to 'true' for fraud dev

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -295,7 +295,7 @@ Mappings:
       integration: "false"
       production: "false"
     di-ipv-cri-fraud-api:
-      dev: "false"
+      dev: "true"
       build: "false"
       staging: "false"
       integration: "false"
@@ -340,7 +340,7 @@ Mappings:
       integration: "false"
       production: "false"
     di-ipv-cri-fraud-api:
-      dev: "false"
+      dev: "true"
       build: "false"
       staging: "false"
       integration: "false"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

ENV_VAR_FEATURE_FLAG_KEY_ROTATION and KeyRotationLegacyFallBack switched to 'true' for fraud-dev to allow for migration and key rotation in fraud dev.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1733](https://govukverify.atlassian.net/browse/LIME-1733)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1733]: https://govukverify.atlassian.net/browse/LIME-1733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ