### PR TITLE
LIME-1738 KeyRotation and LegacyKey flags set to 'true' for dl dev

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -307,7 +307,7 @@ Mappings:
       integration: "false"
       production: "false"
     di-ipv-cri-dl-api:
-      dev: "false"
+      dev: "true"
       build: "false"
       staging: "false"
       integration: "false"
@@ -352,7 +352,7 @@ Mappings:
       integration: "false"
       production: "false"
     di-ipv-cri-dl-api:
-      dev: "false"
+      dev: "true"
       build: "false"
       staging: "false"
       integration: "false"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

### What changed

ENV_VAR_FEATURE_FLAG_KEY_ROTATION and KeyRotationLegacyFallBack switched to 'true' for dl-dev for the key rotation initiative in fraud dev.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1738](https://govukverify.atlassian.net/browse/LIME-1738)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
