### PR TITLE
LIME-1823: KeyRotation and LegacyKey set to 'true' for Fraud Build.

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -296,7 +296,7 @@ Mappings:
       production: "false"
     di-ipv-cri-fraud-api:
       dev: "true"
-      build: "false"
+      build: "true"
       staging: "false"
       integration: "false"
       production: "false"
@@ -341,7 +341,7 @@ Mappings:
       production: "false"
     di-ipv-cri-fraud-api:
       dev: "false"
-      build: "false"
+      build: "true"
       staging: "false"
       integration: "false"
       production: "false"


### PR DESCRIPTION
### What changed

ENV_VAR_FEATURE_FLAG_KEY_ROTATION and KeyRotationLegacyFallBack switched to 'true' for Fraud Build to allow for migration and key rotation in Fraud Build.

### Issue tracking

- [LIME-1823](https://govukverify.atlassian.net/browse/LIME-1823)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1823]: https://govukverify.atlassian.net/browse/LIME-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ