### PR TITLE
OJ-3254 - Enable key rotation feature flag in NINo check staging

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -327,7 +327,7 @@ Mappings:
     di-ipv-cri-check-hmrc-api:
       dev: "true"
       build: "true"
-      staging: "false"
+      staging: "true"
       integration: "false"
       production: "false"
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Enabled key rotation feature flag in NINo check staging environment

### Why did it change

- We want to move towards having JWKS in use for encryption in all environments

### Issue tracking

OJ-3254

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
