### PR TITLE
LIME-1823: Return LegacyFallbackKey flag to false in Fraud Build.

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -341,7 +341,7 @@ Mappings:
       production: "false"
     di-ipv-cri-fraud-api:
       dev: "false"
-      build: "true"
+      build: "false"
       staging: "false"
       integration: "false"
       production: "false"


### PR DESCRIPTION
### What changed

Returned KeyRotationLegacyFallBackMapping to "false" for Fraud Build as we have now migrated to the automated key-rotation process for Fraud Build. 

### Issue tracking

- [LIME-1823](https://govukverify.atlassian.net/browse/LIME-1823)

## Checklists

### Environment variables or secrets

- [] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1823]: https://govukverify.atlassian.net/browse/LIME-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ