### PR TITLE
OJ-3348 - Enable provisioned concurrency in check build+prod

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -416,10 +416,10 @@ Mappings:
       production: 0
     di-ipv-cri-check-hmrc-api:
       dev: 0
-      build: 0
+      build: 1
       staging: 0
       integration: 0
-      production: 0
+      production: 1
 
   # CANNOT be >= 1 with JavaSnapStart enabled - (Enables per cri&env role out)
   JavaProvisionedConcurrencyMapping:


### PR DESCRIPTION
## Proposed changes

### What changed

- Enabled Lambda provisioned concurrency (=1) on common lambdas in NINo Check build + prod

### Why did it change

- The NINo check flow is not used regularly enough to consistently have at least one warm Lambda, meaning we often see cold starts that affect user experience and compromise our adherence to NFRs

### Issue tracking

- OJ-3348

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
