### PR TITLE
LIME-1824: KeyRotation and LegacyKey set to 'true' for DL Build.

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -308,7 +308,7 @@ Mappings:
       production: "false"
     di-ipv-cri-dl-api:
       dev: "true"
-      build: "false"
+      build: "true"
       staging: "false"
       integration: "false"
       production: "false"
@@ -353,7 +353,7 @@ Mappings:
       production: "false"
     di-ipv-cri-dl-api:
       dev: "false"
-      build: "false"
+      build: "true"
       staging: "false"
       integration: "false"
       production: "false"


### PR DESCRIPTION
### What changed

ENV_VAR_FEATURE_FLAG_KEY_ROTATION and KeyRotationLegacyFallBack switched to 'true' for Driving License Build to allow for migration and key rotation in Driving License Build.

### Issue tracking

- [LIME-1824](https://govukverify.atlassian.net/browse/LIME-1824)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
