### PR TITLE
LIME-1782: Enabling core jwks endpoint signing key consumption for fraud integration

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -180,7 +180,7 @@ Mappings:
       dev: true
       build: true
       staging: true
-      integration: false
+      integration: true
       production: false
     di-ipv-cri-kbv-api:
       dev: true


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Feature flag turned on for fraud integration, to enable consumption of signing key on core's jwks endpoint.
<!-- Describe the changes in detail - the "what"-->

### Why did it change

Once endpoint is in use,  enables later (core) signing key rotation capability. 
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1782](https://govukverify.atlassian.net/browse/LIME-1782)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
