### PR TITLE
LIME-1824: Return LegacyFallbackKey flag to false in DL Build.

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -353,7 +353,7 @@ Mappings:
       production: "false"
     di-ipv-cri-dl-api:
       dev: "false"
-      build: "true"
+      build: "false"
       staging: "false"
       integration: "false"
       production: "false"


### PR DESCRIPTION
### What changed

Returned KeyRotationLegacyFallBackMapping to "false" for Driving License Build as we have now migrated to the automated key-rotation process for Driving License Build.

### Issue tracking

- [LIME-1824](https://govukverify.atlassian.net/browse/LIME-1824)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1824]: https://govukverify.atlassian.net/browse/LIME-1824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ