### PR TITLE
OJ-3254: Enable key rotation env vars

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -327,7 +327,7 @@ Mappings:
     di-ipv-cri-check-hmrc-api:
       dev: "true"
       build: "true"
-      staging: "false"
+      staging: "true"
       integration: "false"
       production: "false"
 
@@ -372,7 +372,7 @@ Mappings:
     di-ipv-cri-check-hmrc-api:
       dev: "true"
       build: "true"
-      staging: "false"
+      staging: "true"
       integration: "false"
       production: "false"
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enable the feature flags `ENV_VAR_FEATURE_FLAG_KEY_ROTATION` and `ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK` for check HMRC CRI in staging

### Why did it change

Because we are doing a key rotation in staging tomorrow

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3254](https://govukverify.atlassian.net/browse/OJ-3254)



[OJ-3254]: https://govukverify.atlassian.net/browse/OJ-3254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ