### PR TITLE
OJ-3255: update key rotation feature flags

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -328,8 +328,8 @@ Mappings:
       dev: "true"
       build: "true"
       staging: "true"
-      integration: "false"
-      production: "false"
+      integration: "true"
+      production: "true"
 
   # Enable fall back with key rotation aliases in session decryption
   KeyRotationLegacyFallBackMapping:
@@ -373,8 +373,8 @@ Mappings:
       dev: "true"
       build: "true"
       staging: "true"
-      integration: "false"
-      production: "false"
+      integration: "true"
+      production: "true"
 
   # TS functions Only 0 = off
   TSProvisionedConcurrencyMapping:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enable the feature flags `ENV_VAR_FEATURE_FLAG_KEY_ROTATION` and `ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK` for check HMRC CRI in int and prod

### Why did it change

Because we are doing key rotations in int and prod tomorrow

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3255](https://govukverify.atlassian.net/browse/OJ-3255)



[OJ-3254]: https://govukverify.atlassian.net/browse/OJ-3254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ