### PR TITLE
LIME-1816 Fraud CRI (Staging) - disable KeyRotationLegacyFallBackMapping

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -342,7 +342,7 @@ Mappings:
     di-ipv-cri-fraud-api:
       dev: "false"
       build: "false"
-      staging: "true"
+      staging: "false"
       integration: "false"
       production: "false"
     di-ipv-cri-kbv-api:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fraud CRI (Staging) disable KeyRotationLegacyFallBackMapping

### Why did it change

Fraud Staging is now using alias based rotated keys

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1816](https://govukverify.atlassian.net/browse/LIME-1816)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1816]: https://govukverify.atlassian.net/browse/LIME-1816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ