### PR TITLE
OJ-3255: turn on key rotation in stub

### DIFF
--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -56,8 +56,8 @@ Mappings:
       dev: true
       build: true
       staging: true
-      integration: false
-      production: false
+      integration: true
+      production: true
 
   TestHarnessUrl:
     di-ipv-cri-check-hmrc-api:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Turn on `KEY_ROTATION_FEATURE_FLAG_ENABLED` 

### Why did it change

So that the headless core stub uses the public encryption keys from the jwks endpoint to encrypt the JWTs that it produces

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3255](https://govukverify.atlassian.net/browse/OJ-3255)


[OJ-3254]: https://govukverify.atlassian.net/browse/OJ-3254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OJ-3255]: https://govukverify.atlassian.net/browse/OJ-3255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ