### PR TITLE
LIME-1781 DL Int and Prod | Enabling core signing key consumption

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -192,8 +192,8 @@ Mappings:
       dev: true
       build: true
       staging: true
-      integration: false
-      production: false
+      integration: true
+      production: true
     di-ipv-cri-passport-api:
       dev: true
       build: true


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Feature flag turned on for DL integration and production, to enable consumption of signing key on core's jwks endpoint.

### Why did it change

Once endpoint is in use, enables later (core) signing key rotation capability.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1781](https://govukverify.atlassian.net/browse/LIME-1781)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

