### PR TITLE
LIME-1817 Fraud Int disable fallback mapping

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -343,7 +343,7 @@ Mappings:
       dev: "false"
       build: "false"
       staging: "false"
-      integration: "true"
+      integration: "false"
       production: "false"
     di-ipv-cri-kbv-api:
       dev: "true"


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fraud CRI (Integration) disable KeyRotationLegacyFallBackMapping

### Why did it change

Fraud Int is now using alias based rotated keys

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1817](https://govukverify.atlassian.net/browse/LIME-1817)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed



[LIME-1817]: https://govukverify.atlassian.net/browse/LIME-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ