### PR TITLE
Fraud CRI (prod) - disable KeyRotationLegacyFallBackMapping

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -344,7 +344,7 @@ Mappings:
       build: "false"
       staging: "false"
       integration: "false"
-      production: "true"
+      production: "false"
     di-ipv-cri-kbv-api:
       dev: "true"
       build: "true"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Fraud CRI (Prod) disable KeyRotationLegacyFallBackMapping

### Why did it change

Fraud Prod is now using alias based rotated keys

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1818](https://govukverify.atlassian.net/browse/LIME-1818)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[LIME-1818]: https://govukverify.atlassian.net/browse/LIME-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ