### PR TITLE
OJ-3256: feat - turn on key rotation for staging in stubs

### DIFF
--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -48,7 +48,7 @@ Mappings:
       localdev: true
       dev: true
       build: true
-      staging: false
+      staging: true
       integration: false
       production: false
     di-ipv-cri-check-hmrc-api:


### PR DESCRIPTION

## Proposed changes

### What changed

Turn on `KEY_ROTATION_FEATURE_FLAG_ENABLED`

### Why did it change

So that the headless core stub uses the public encryption keys from the jwks endpoint to encrypt the JWTs that it produces

### Issue tracking

- [OJ-3256](https://govukverify.atlassian.net/browse/OJ-3256)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3256]: https://govukverify.atlassian.net/browse/OJ-3256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ