### PR TITLE
OJ-3256: feat - enable key rotation env variables in staging

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -303,7 +303,7 @@ Mappings:
     di-ipv-cri-kbv-api:
       dev: "true"
       build: "true"
-      staging: "false"
+      staging: "true"
       integration: "false"
       production: "false"
     di-ipv-cri-dl-api:
@@ -348,7 +348,7 @@ Mappings:
     di-ipv-cri-kbv-api:
       dev: "true"
       build: "true"
-      staging: "false"
+      staging: "true"
       integration: "false"
       production: "false"
     di-ipv-cri-dl-api:


### PR DESCRIPTION

## Proposed changes

### What changed

Enable the feature flags `ENV_VAR_FEATURE_FLAG_KEY_ROTATION` and the `ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK` for KBV CRI in Staging.

### Why did it change

To enable key rotation in Staging

### Issue tracking

- [OJ-3256](https://govukverify.atlassian.net/browse/OJ-3256)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3256]: https://govukverify.atlassian.net/browse/OJ-3256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ