### PR TITLE
LIME-1843 Update dynatrace layer version for node and java functions

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -811,14 +811,7 @@ Resources:
       Handler: uk.gov.di.ipv.cri.common.api.handler.SessionHandler::handleRequest
       Runtime: java17
       Layers:
-        - !Sub
-          - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"
-          - SecretArn:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                dynatraceSecretArn,
-              ]
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
       VpcConfig:
         SubnetIds: !If
           - IsDevPlatformDeploy
@@ -976,14 +969,7 @@ Resources:
       Handler: session-handler.lambdaHandler
       Runtime: nodejs22.x
       Layers:
-        - !Sub
-          - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
-          - SecretArn:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                dynatraceSecretArn,
-              ]
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_2_20250307-045250_with_collector_nodejs:1
       VpcConfig:
         SubnetIds: !If
           - IsDevPlatformDeploy
@@ -1111,14 +1097,7 @@ Resources:
       Handler: uk.gov.di.ipv.cri.common.api.handler.AuthorizationHandler::handleRequest
       Runtime: java17
       Layers:
-        - !Sub
-          - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"
-          - SecretArn:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                dynatraceSecretArn,
-              ]
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
       VpcConfig:
         SubnetIds: !If
           - IsDevPlatformDeploy
@@ -1236,14 +1215,7 @@ Resources:
       Handler: authorization-handler.lambdaHandler
       Runtime: nodejs22.x
       Layers:
-        - !Sub
-          - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
-          - SecretArn:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                dynatraceSecretArn,
-              ]
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_2_20250307-045250_with_collector_nodejs:1
       VpcConfig:
         SubnetIds: !If
           - IsDevPlatformDeploy
@@ -1357,14 +1329,7 @@ Resources:
       Handler: uk.gov.di.ipv.cri.common.api.handler.AccessTokenHandler::handleRequest
       Runtime: java17
       Layers:
-        - !Sub
-          - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"
-          - SecretArn:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                dynatraceSecretArn,
-              ]
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
       VpcConfig:
         SubnetIds: !If
           - IsDevPlatformDeploy
@@ -1478,14 +1443,7 @@ Resources:
       CodeUri: ../../lambdas
       Runtime: nodejs22.x
       Layers:
-        - !Sub
-          - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
-          - SecretArn:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                dynatraceSecretArn,
-              ]
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_2_20250307-045250_with_collector_nodejs:1
       VpcConfig:
         SubnetIds: !If
           - IsDevPlatformDeploy
@@ -2251,14 +2209,7 @@ Resources:
       Handler: create-auth-code-handler.lambdaHandler
       Runtime: nodejs22.x
       Layers:
-        - !Sub
-          - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
-          - SecretArn:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                dynatraceSecretArn,
-              ]
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_2_20250307-045250_with_collector_nodejs:1
       VpcConfig:
         SubnetIds: !If
           - IsDevPlatformDeploy


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Dynatrace OneAgent Layer first needs to resolve to v1_311 before then updating the version to v1_313.

### Why did it change

There’s a bug in the {{resolve:secretsmanager}} syntax that prevents the current configuration from deploying the latest available Dynatrace layer.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1843](https://govukverify.atlassian.net/browse/LIME-1843)




[LIME-1843]: https://govukverify.atlassian.net/browse/LIME-1843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ