### PR TITLE
OJ-3257: Turn on key rotation for KBV

### DIFF
--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -49,8 +49,8 @@ Mappings:
       dev: true
       build: true
       staging: true
-      integration: false
-      production: false
+      integration: true
+      production: true
     di-ipv-cri-check-hmrc-api:
       localdev: true
       dev: true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Turn on key rotation for KBV

### Why did it change

So that journeys starting from the stub use public encryption keys from our jwks endpoint.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3257](https://govukverify.atlassian.net/browse/OJ-3257)



[OJ-3257]: https://govukverify.atlassian.net/browse/OJ-3257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ