### PR TITLE
OJ-3232: Enable keyRotation flags for address in staging

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -291,7 +291,7 @@ Mappings:
     di-ipv-cri-address-api:
       dev: "true"
       build: "true"
-      staging: "false"
+      staging: "true"
       integration: "false"
       production: "false"
     di-ipv-cri-fraud-api:
@@ -336,7 +336,7 @@ Mappings:
     di-ipv-cri-address-api:
       dev: "false"
       build: "false"
-      staging: "false"
+      staging: "true"
       integration: "false"
       production: "false"
     di-ipv-cri-fraud-api:


### PR DESCRIPTION
### What changed

Enable the feature flags ENV_VAR_FEATURE_FLAG_KEY_ROTATION and ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK for Address in Staging

### Why did it change

To support key rotation in Staging environment

### Issue tracking

- [OJ-3232](https://govukverify.atlassian.net/browse/OJ-3232)
