### PR TITLE
OJ-3232: Turn on key rotation for address in Staging

### DIFF
--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -41,7 +41,7 @@ Mappings:
       localdev: true
       dev: true
       build: true
-      staging: false
+      staging: true
       integration: false
       production: false
     di-ipv-cri-kbv-api:


### PR DESCRIPTION
### What changed

We've enabled key rotation flags in Address staging
https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/571

### Why did it change

Enabling key rotation in Address staging

### Issue tracking


- [OJ-3232](https://govukverify.atlassian.net/browse/OJ-3232)

[OJ-3232]: https://govukverify.atlassian.net/browse/OJ-3232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ