### PR TITLE
LIME-1819 DL CRI (Staging) - disable KeyRotationLegacyFallBackMapping

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -354,7 +354,7 @@ Mappings:
     di-ipv-cri-dl-api:
       dev: "false"
       build: "false"
-      staging: "true"
+      staging: "false"
       integration: "false"
       production: "false"
     di-ipv-cri-passport-api:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

DL CRI (Staging) disable KeyRotationLegacyFallBackMapping

### Why did it change

DL Staging is now using alias based rotated keys

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1819](https://govukverify.atlassian.net/browse/LIME-1819)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


[LIME-1819]: https://govukverify.atlassian.net/browse/LIME-1819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ