### PR TITLE
LIME-1820 DL CRI (Integration) - disable key rotation fallback mapping

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -355,7 +355,7 @@ Mappings:
       dev: "false"
       build: "false"
       staging: "false"
-      integration: "true"
+      integration: "false"
       production: "false"
     di-ipv-cri-passport-api:
       dev: "false"


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

DL CRI (Integration) disable KeyRotationLegacyFallBackMapping

### Why did it change

DL Integration is now using alias based rotated keys

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1820](https://govukverify.atlassian.net/browse/LIME-1820)



[LIME-1820]: https://govukverify.atlassian.net/browse/LIME-1820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ