### PR TITLE
LIME-1821 revert KeyRotationLegacyFallBackMapping to false in DL Prod

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -356,7 +356,7 @@ Mappings:
       build: "false"
       staging: "false"
       integration: "false"
-      production: "true"
+      production: "false"
     di-ipv-cri-passport-api:
       dev: "false"
       build: "false"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Revert KeyRotationLegacyFallBackMapping feature flag to false in DL Prod

### Why did it change

Key migration and key rotation have been successfully executed in DL prod 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1821](https://govukverify.atlassian.net/browse/LIME-1821)




[LIME-1821]: https://govukverify.atlassian.net/browse/LIME-1821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ