### PR TITLE
OJ-3251 - Enable key rotation feature flag in address int+prod

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -292,8 +292,8 @@ Mappings:
       dev: "true"
       build: "true"
       staging: "true"
-      integration: "false"
-      production: "false"
+      integration: "true"
+      production: "true"
     di-ipv-cri-fraud-api:
       dev: "true"
       build: "true"
@@ -337,8 +337,8 @@ Mappings:
       dev: "false"
       build: "false"
       staging: "true"
-      integration: "false"
-      production: "false"
+      integration: "true"
+      production: "true"
     di-ipv-cri-fraud-api:
       dev: "false"
       build: "false"


### PR DESCRIPTION
## Proposed changes

### What changed

- Enabled key rotation in address int+prod common lambdas

### Why did it change

- We are running the first key rotations for address later this week

### Issue tracking

- OJ-3251

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
