### PR TITLE
OJ-3251 - Enable key rotation for stubs in address int+prod

### DIFF
--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -42,8 +42,8 @@ Mappings:
       dev: true
       build: true
       staging: true
-      integration: false
-      production: false
+      integration: true
+      production: true
     di-ipv-cri-kbv-api:
       localdev: true
       dev: true


### PR DESCRIPTION
## Proposed changes

### What changed

- Turned on key rotation feature flags for core stubs in address int+prod

### Why did it change

- We want the core stubs to use the new key infrastructure

### Issue tracking

- OJ-3251

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
