### PR TITLE
OJ-3457: Add FMS tags to pre-merge APIGW and test-resources APIGW

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -2291,6 +2291,9 @@ Resources:
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
         Type: REGIONAL
+      Tags:
+        FMSRegionalPolicy: false
+        CustomPolicy: true
 
   PreMergeDevOnlyApiAccessLogGroup:
     Type: AWS::Logs::LogGroup

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -364,6 +364,11 @@ Resources:
           Name: AWS::Include
           Parameters:
             Location: public-api.yaml
+      Tags:
+        - Key: FMSRegionalPolicy
+          Value: false
+        - Key: CustomPolicy
+          Value: true
       Policy:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Apply tagging conditional to our regional API GW resources that support testing. Tags added to;
- Common lambdas pre merge API
- Test resources API

Note: `AWS::ApiGateway::RestApi` requires tags to be an array of key-value pairs

### Why did it change

As part of transitioning FMS WAF rule enforcement from COUNT to BLOCK, Security have set up custom policies for us to apply to our resources in scope. In COUNT mode FMS merely logs the rule violations, in BLOCK mode violating requests are actively blocked.

### Issue tracking

- [OJ-3457](https://govukverify.atlassian.net/browse/OJ-3457)

[OJ-3457]: https://govukverify.atlassian.net/browse/OJ-3457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ