### PR TITLE
OJ-2550: chore - remove the evidenceRequested.context from code and u…

### DIFF
--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -126,18 +126,11 @@ export class SessionLambda implements LambdaInterface {
                 },
             }),
             ...(evidenceRequested && {
-                extensions: {
-                    evidence: [
-                        {
-                            context: "identity_check",
-                        },
-                    ],
-                    ...(evidenceRequested.verificationScore && {
-                        evidence_requested: {
-                            verificationScore: evidenceRequested.verificationScore,
-                        },
-                    }),
-                },
+                ...(evidenceRequested.verificationScore && {
+                    evidence_requested: {
+                        verificationScore: evidenceRequested.verificationScore,
+                    },
+                }),
             }),
         });
     }

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -125,12 +125,11 @@ export class SessionLambda implements LambdaInterface {
                     },
                 },
             }),
-            ...(evidenceRequested && {
-                ...(evidenceRequested.verificationScore && {
-                    evidence_requested: {
-                        verificationScore: evidenceRequested.verificationScore,
-                    },
-                }),
+
+            ...(evidenceRequested?.verificationScore && {
+                evidence_requested: {
+                    verificationScore: evidenceRequested.verificationScore,
+                },
             }),
         });
     }

--- a/lambdas/tests/unit/handlers/session-handler.test.ts
+++ b/lambdas/tests/unit/handlers/session-handler.test.ts
@@ -611,7 +611,7 @@ describe("SessionLambda", () => {
             );
         });
 
-        it("should save the session details with the context field but still audit identity_check context", async () => {
+        it("should save the session details without the context field", async () => {
             jest.spyOn(sessionRequestValidator.prototype, "validateJwt").mockReturnValue(
                 new Promise<JWTPayload>((res) =>
                     res({

--- a/lambdas/tests/unit/handlers/session-handler.test.ts
+++ b/lambdas/tests/unit/handlers/session-handler.test.ts
@@ -432,37 +432,6 @@ describe("SessionLambda", () => {
         expect(result.body).toContain("1025: Request failed due to a server error");
     });
 
-    it("should save the session details with the context field", async () => {
-        jest.spyOn(sessionRequestValidator.prototype, "validateJwt").mockReturnValue(
-            new Promise<JWTPayload>((res) =>
-                res({
-                    client_id: "test-client-id",
-                    govuk_signin_journey_id: "test-journey-id",
-                    persistent_session_id: "test-persistent-session-id",
-                    redirect_uri: "test-redirect-uri",
-                    state: "test-state",
-                    sub: "test-sub",
-                    shared_claims: mockPerson,
-                    context: "test-context",
-                } as JWTPayload),
-            ),
-        );
-        const spy = jest.spyOn(sessionService.prototype, "saveSession");
-        await lambdaHandler(mockEvent, {} as Context);
-
-        const expectedSessionRequestSummary = {
-            clientId: "test-client-id",
-            clientIpAddress: "test-client-ip-address",
-            clientSessionId: "test-journey-id",
-            persistentSessionId: "test-persistent-session-id",
-            redirectUri: "test-redirect-uri",
-            state: "test-state",
-            subject: "test-sub",
-            context: "test-context",
-        };
-        expect(spy).toHaveBeenCalledWith(expectedSessionRequestSummary);
-    });
-
     describe("SessionLambda has evidenceRequested", () => {
         const previousCriIdentifier = process.env.CRI_IDENTIFIER as string;
         beforeEach(() => {
@@ -547,15 +516,8 @@ describe("SessionLambda", () => {
                     persistentSessionId: "test-persistent-session-id",
                     clientSessionId: "test-journey-id",
                 },
-                extensions: {
-                    evidence: [
-                        {
-                            context: "identity_check",
-                        },
-                    ],
-                    evidence_requested: {
-                        verificationScore: 2,
-                    },
+                evidence_requested: {
+                    verificationScore: 2,
                 },
             });
         });
@@ -589,13 +551,6 @@ describe("SessionLambda", () => {
                     subject: "test-sub",
                     persistentSessionId: "test-persistent-session-id",
                     clientSessionId: "test-journey-id",
-                },
-                extensions: {
-                    evidence: [
-                        {
-                            context: "identity_check",
-                        },
-                    ],
                 },
             });
         });
@@ -672,7 +627,6 @@ describe("SessionLambda", () => {
                             strengthScore: 2,
                             verificationScore: 2,
                         },
-                        context: "test-context",
                     } as JWTPayload),
                 ),
             );
@@ -694,7 +648,6 @@ describe("SessionLambda", () => {
                     strengthScore: 2,
                     verificationScore: 2,
                 },
-                context: "test-context",
             };
             expect(spySaveSession).toHaveBeenCalledWith(expectedSessionRequestSummary);
 
@@ -706,15 +659,8 @@ describe("SessionLambda", () => {
                     persistentSessionId: "test-persistent-session-id",
                     clientSessionId: "test-journey-id",
                 },
-                extensions: {
-                    evidence: [
-                        {
-                            context: "identity_check",
-                        },
-                    ],
-                    evidence_requested: {
-                        verificationScore: 2,
-                    },
+                evidence_requested: {
+                    verificationScore: 2,
                 },
             });
         });


### PR DESCRIPTION
## Proposed changes

### What changed

- Removed `extensions.evidence.context` object from sendAudit method in the session handler.
- Update associated unit tests to remove `extensions.evidence.context` 

### Why did it change

Given that HMRC KBV is NOT going live, the Check HMRC CRI will only be used for identity checking. Can remove the additional conditional logic from the START event populating the `context` field as there is no longer multiple contexts

### Issue tracking

- [OJ-2550](https://govukverify.atlassian.net/browse/OJ-2550)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2550]: https://govukverify.atlassian.net/browse/OJ-2550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ