### PR TITLE
OJ-3462: Add param to force dev Java lambdas to update when env var c…

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -69,6 +69,10 @@ jobs:
       stack-name: ${{ steps.deploy.outputs.stack-name }}
       stack-outputs: ${{ steps.deploy.outputs.stack-outputs }}
     steps:
+      - name: Set timestamp
+        id: set_timestamp
+        run: echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
+
       - name: Deploy stack
         uses: govuk-one-login/github-actions/sam/deploy-stack@ca188729ecb0c92e5fe5ae7c024f9894815da3a1
         id: deploy
@@ -88,3 +92,4 @@ jobs:
             cri:deployment-source=github-actions
           parameters: |
             Environment=dev
+            ForceLambdaUpdate=${{ steps.set_timestamp.outputs.timestamp }}

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,4 +31,5 @@ sam deploy --stack-name "$stack_name" \
   --parameter-overrides \
   Environment=dev \
   ${audit_event_name_prefix:+AuditEventNamePrefix=$audit_event_name_prefix} \
-  ${cri_identifier:+CriIdentifier=$cri_identifier}
+  ${cri_identifier:+CriIdentifier=$cri_identifier} \
+  ForceLambdaUpdate="$(date +%s)"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -8,6 +8,7 @@ Metadata:
     config:
       ignore_checks:
         - W8003
+        - W1028
         - E3031
         - E3033
         - E1020
@@ -48,6 +49,10 @@ Parameters:
     Description: "Specifies the configuration to enable gradual Lambda deployments. This value is picked up from the LambdaCanaryDeployment on the pipeline "
     Type: String
     Default: AllAtOnce
+  ForceLambdaUpdate:
+    Type: String
+    Default: "initial"
+    Description: "For dev only - used to force Java Lambda version updates for locally deployed and pre-merge stacks"
 
 Conditions:
   UseCodeSigningConfigArn:
@@ -123,6 +128,7 @@ Globals:
         POWERTOOLS_LOG_LEVEL: INFO
         POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
         SQS_AUDIT_EVENT_PREFIX: !Ref AuditEventNamePrefix
+        FORCE_LAMBDA_UPDATE: !If [IsDevEnvironment, !Ref ForceLambdaUpdate, !Ref AWS::NoValue]
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
         DT_CONNECTION_AUTH_TOKEN: !Sub
           - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}"


### PR DESCRIPTION
## Proposed changes

### What changed

Add `ForceLambdaUpdate` CF param and env var that can be used to force local dev and pre merge stacks to deploy new lambda versions for Java lambdas if only an env var changes.

Note: I also had to ignore cfn-lint `W1028`. If I add a default `E1011` flags as we have mappings without the default env. 

### Why did it change

With moving to resolving SSM Params at deploy time and passing them directly into our Lambda functions as environment variables, when deploying using Sam (local or pre-merge GHA) sometimes the small changes (e.g. an env var) do not publish new Lambda versions for Java lambdas. This can cause deployment issues.

### Issue tracking
- [OJ-3462](https://govukverify.atlassian.net/browse/OJ-3462)
