### PR TITLE
Support localdev stacks in test-resources callback function

### DIFF
--- a/test-resources/headless-core-stub/lambdas/start/src/services/jwt-claims-set-service.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/services/jwt-claims-set-service.ts
@@ -87,18 +87,18 @@ export const validateClaimsSet = (claimsSet: JWTClaimsSet) => {
 };
 
 const createState = (audience: string, redirectUri: string, existingState?: string): string => {
-    const defaultStatePayload = { aud: audience, redirect_uri: redirectUri };
+    const defaultState = { aud: audience, redirect_uri: redirectUri };
 
     if (!existingState) {
-        return base64Encode(JSON.stringify(defaultStatePayload));
+        return base64Encode(JSON.stringify(defaultState));
     }
 
     try {
         const decodedState = JSON.parse(base64Decode(existingState));
-        const mergedState = { ...defaultStatePayload, ...decodedState };
+        const mergedState = { ...defaultState, ...decodedState };
         return base64Encode(JSON.stringify(mergedState));
     } catch {
-        return base64Encode(JSON.stringify(defaultStatePayload));
+        return base64Encode(JSON.stringify(defaultState));
     }
 };
 

--- a/test-resources/headless-core-stub/lambdas/start/src/services/jwt-claims-set-service.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/services/jwt-claims-set-service.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import { ClaimsSetOverrides } from "../types/claims-set-overrides";
 import { JWTClaimsSet } from "../types/jwt-claims-set";
 import { logger } from "../start-handler";
-import { base64Encode } from "../../../../utils/src/base64";
+import { base64Encode, base64Decode } from "../../../../utils/src/base64";
 import { HeadlessCoreStubError } from "../../../../utils/src/errors/headless-core-stub-error";
 import { DEFAULT_CLIENT_ID } from "../../../../utils/src/constants";
 
@@ -30,7 +30,7 @@ export const generateJwtClaimsSet = async (overrides: ClaimsSetOverrides, ssmPar
     const audience = overrides.aud || ssmParameters["audience"];
     const issuer = overrides.iss || ssmParameters["issuer"];
     const redirectUri = overrides.redirect_uri || ssmParameters["redirectUri"];
-    const state = overrides.state || base64Encode(JSON.stringify({ aud: audience, redirect_uri: redirectUri }));
+    const state = createState(audience, redirectUri, overrides.state);
 
     const now = Date.now();
     return {
@@ -84,6 +84,22 @@ export const validateClaimsSet = (claimsSet: JWTClaimsSet) => {
         throw new HeadlessCoreStubError("Claims set failed validation" + errorDetails, 400);
     }
     logger.info("Called validateClaimsSet validated schema successfully");
+};
+
+const createState = (audience: string, redirectUri: string, existingState?: string): string => {
+    const defaultStatePayload = { aud: audience, redirect_uri: redirectUri };
+
+    if (!existingState) {
+        return base64Encode(JSON.stringify(defaultStatePayload));
+    }
+
+    try {
+        const decodedState = JSON.parse(base64Decode(existingState));
+        const mergedState = { ...defaultStatePayload, ...decodedState };
+        return base64Encode(JSON.stringify(mergedState));
+    } catch {
+        return base64Encode(JSON.stringify(defaultStatePayload));
+    }
 };
 
 const msToSeconds = (ms: number) => Math.floor(ms / 1000);


### PR DESCRIPTION
## What

In order to allow headless core stub to be used with developer api stacks, the token and credential endpoints require the api of the stack to be supplied. A way to do this is to pass it from the front end stack as an encoded json string as the `state` value of the `shared_claims` doing this way means the shape of requests from the front does not need to change. The state is the responsibility of the `stub` as it the responsibility of `ipv-core`

see
https://github.com/govuk-one-login/architecture/blob/main/rfc/0001-crossteam-oauth-profile.md#requests-to-the-authorization-endpoint
https://github.com/govuk-one-login/architecture/blob/main/rfc/0085-address-cri.md
### What changed


### How

This PR shows, the changes needed to make this happen
the frontend encodes the values here  https://github.com/govuk-one-login/ipv-cri-address-front/blob/664634b57eab665b75bad0b8f8bd2477a415219c/test/browser/utils/stub-oauth-url-generator.js#L10-L21
