### PR TITLE
OJ-3554(spike): DynamoDB streams

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -53,14 +53,6 @@ Parameters:
     Type: String
     Default: "initial"
     Description: "For dev only - used to force Java Lambda version updates for locally deployed and pre-merge stacks"
-  TargetSessionTableName:
-    Type: String
-    Default: "none"
-    Description: "The name of the target session table for DynamoDB stream replication"
-  TargetPersonIdentityTableName:
-    Type: String
-    Default: "none"
-    Description: "The name of the target person identity table for DynamoDB stream replication"
   BuildNotificationStackName:
     Description: The topic to publish notification and sns alerts
     Type: String
@@ -98,15 +90,14 @@ Conditions:
   IsDevEnvironment: !Equals
     - !Ref Environment
     - dev
-  EnableDynamoDbStreamReplication:
-    Fn::Not:
-      - Fn::Or:
-          - Fn::Equals:
-              - !Ref TargetSessionTableName
-              - "none"
-          - Fn::Equals:
-              - !Ref TargetPersonIdentityTableName
-              - "none"
+  EnableDynamoDbStreamReplication: !And
+  - !Equals
+      - !FindInMap [EnableDynamoDbStream, !Ref CriIdentifier, !Ref Environment]
+      - true
+  - !Not # Prevent it enabling in common-dev & common-build as the CriIdentifier is di-ipv-cri-check-hmrc-api in those accounts
+      - !Equals
+          - !Ref AuditEventNamePrefix
+          - IPV_COMMON_CRI
   EnableDynamoDbStreamCSLS: !And
     - !Condition EnableDynamoDbStreamReplication
     - !Condition IsCSLSDisabled
@@ -201,8 +192,50 @@ Globals:
               ]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
 
-
 Mappings:
+  EnableDynamoDbStream:
+    di-ipv-cri-address-api:
+      dev: false
+      build: false
+      staging: false
+      integration: false
+      production: false
+    di-ipv-cri-fraud-api:
+      dev: false
+      build: false
+      staging: false
+      integration: false
+      production: false
+    di-ipv-cri-kbv-api:
+      dev: false
+      build: false
+      staging: false
+      integration: false
+      production: false
+    di-ipv-cri-dl-api:
+      dev: false
+      build: false
+      staging: false
+      integration: false
+      production: false
+    di-ipv-cri-passport-api:
+      dev: false
+      build: false
+      staging: false
+      integration: false
+      production: false
+    di-ipv-cri-kbv-hmrc-api:
+      dev: false
+      build: false
+      staging: false
+      integration: false
+      production: false
+    di-ipv-cri-check-hmrc-api:
+      dev: false
+      build: false
+      staging: false
+      integration: false
+      production: false
 
   CustomerManagedKey:
     di-ipv-cri-address-api:
@@ -1670,19 +1703,24 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-dynamodb-stream"
           SOURCE_SESSION_TABLE_NAME: !Ref SessionTable
           SOURCE_PERSON_IDENTITY_TABLE_NAME: !Ref PersonIdentityTable
-          TARGET_SESSION_TABLE_NAME: !Ref TargetSessionTableName
-          TARGET_PERSON_IDENTITY_TABLE_NAME: !Ref TargetPersonIdentityTableName
+          TARGET_SESSION_TABLE_NAME: !Sub "{{resolve:ssm:/common-cri/oauth-common/OAuthSessionTableName}}"
+          TARGET_PERSON_IDENTITY_TABLE_NAME: !Sub "{{resolve:ssm:/common-cri/oauth-common/OAuthPersonIdentityTableName}}"
       AutoPublishAlias: live
       AutoPublishAliasAllProperties: true
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
-        - DynamoDBWritePolicy:
-            TableName: !Ref TargetSessionTableName
-        - DynamoDBWritePolicy:
-            TableName: !Ref TargetPersonIdentityTableName
+        - DynamoDBCrudPolicy:
+            TableName: !Sub "{{resolve:ssm:/common-cri/oauth-common/OAuthSessionTableName}}"
+        - DynamoDBCrudPolicy:
+            TableName: !Sub "{{resolve:ssm:/common-cri/oauth-common/OAuthPersonIdentityTableName}}"
+        - !If
+          - UseCustomerManagedKey
+          - KMSDecryptPolicy:
+              KeyId: !Ref DynamoTablesEncryptionKey
+          - !Ref AWS::NoValue
         - KMSDecryptPolicy:
-            KeyId: !Ref DynamoTablesEncryptionKey
+            KeyId: !Sub "{{resolve:ssm:/common-cri/oauth-common/OAuthCustomerManagedKeyId}}"
       Events:
         SessionTableStream:
           Type: DynamoDB
@@ -1712,9 +1750,14 @@ Resources:
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
+        Format: esm
         Minify: true
-        Target: "node18"
+        Target: es2022
         Sourcemap: true
+        OutExtension:
+          - .js=.mjs
+        Banner:
+          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
         EntryPoints:
           - src/handlers/dynamodb-stream-handler.ts
         External:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -53,6 +53,14 @@ Parameters:
     Type: String
     Default: "initial"
     Description: "For dev only - used to force Java Lambda version updates for locally deployed and pre-merge stacks"
+  TargetSessionTableName:
+    Type: String
+    Default: "none"
+    Description: "The name of the target session table for DynamoDB stream replication"
+  TargetPersonIdentityTableName:
+    Type: String
+    Default: "none"
+    Description: "The name of the target person identity table for DynamoDB stream replication"
   BuildNotificationStackName:
     Description: The topic to publish notification and sns alerts
     Type: String
@@ -90,6 +98,21 @@ Conditions:
   IsDevEnvironment: !Equals
     - !Ref Environment
     - dev
+  EnableDynamoDbStreamReplication:
+    Fn::Not:
+      - Fn::Or:
+          - Fn::Equals:
+              - !Ref TargetSessionTableName
+              - "none"
+          - Fn::Equals:
+              - !Ref TargetPersonIdentityTableName
+              - "none"
+  EnableDynamoDbStreamCSLS: !And
+    - !Condition EnableDynamoDbStreamReplication
+    - !Condition IsCSLSDisabled
+  EnableDynamoDbStreamCanaryAlarms: !And
+    - !Condition EnableDynamoDbStreamReplication
+    - !Condition UseCanaryDeploymentAlarms
   IsDevPlatformDeploy: !Equals
     - !FindInMap [CriVpcMapping, !Ref CriIdentifier, !Ref Environment]
     - "di-devplatform-deploy"
@@ -1617,6 +1640,130 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
+  DynamoDbStreamFunction:
+    Type: AWS::Serverless::Function
+    Condition: EnableDynamoDbStreamReplication
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-DynamoDbStreamFunction"
+      DeploymentPreference:
+        Type: !Ref LambdaDeploymentPreference
+        Role: !GetAtt CodeDeployServiceRole.Arn
+        Alarms: !If
+          - EnableDynamoDbStreamCanaryAlarms
+          - [!Ref DynamoDbStreamFunctionLambdaErrors]
+          - [!Ref AWS::NoValue]
+      CodeUri: ../../lambdas
+      Handler: dynamodb-stream-handler.lambdaHandler
+      Runtime: nodejs22.x
+      Layers:
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_313_2_20250404-043044_with_collector_nodejs:1
+      VpcConfig:
+        SubnetIds: !If
+          - IsDevPlatformDeploy
+          - [
+              !ImportValue cri-vpc-PrivateSubnetIdA,
+              !ImportValue cri-vpc-PrivateSubnetIdB,
+            ]
+          - !Split [",", !ImportValue cri-vpc-PrivateSubnets]
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-dynamodb-stream"
+          SOURCE_SESSION_TABLE_NAME: !Ref SessionTable
+          SOURCE_PERSON_IDENTITY_TABLE_NAME: !Ref PersonIdentityTable
+          TARGET_SESSION_TABLE_NAME: !Ref TargetSessionTableName
+          TARGET_PERSON_IDENTITY_TABLE_NAME: !Ref TargetPersonIdentityTableName
+      AutoPublishAlias: live
+      AutoPublishAliasAllProperties: true
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSXrayWriteOnlyAccess
+        - DynamoDBWritePolicy:
+            TableName: !Ref TargetSessionTableName
+        - DynamoDBWritePolicy:
+            TableName: !Ref TargetPersonIdentityTableName
+        - KMSDecryptPolicy:
+            KeyId: !Ref DynamoTablesEncryptionKey
+      Events:
+        SessionTableStream:
+          Type: DynamoDB
+          Properties:
+            Stream: !GetAtt SessionTable.StreamArn
+            StartingPosition: TRIM_HORIZON
+            BatchSize: 100
+            BisectBatchOnFunctionError: true
+            MaximumRetryAttempts: 3
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+        PersonIdentityTableStream:
+          Type: DynamoDB
+          Properties:
+            Stream: !GetAtt PersonIdentityTable.StreamArn
+            StartingPosition: TRIM_HORIZON
+            BatchSize: 100
+            BisectBatchOnFunctionError: true
+            MaximumRetryAttempts: 3
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
+      ProvisionedConcurrencyConfig:
+        !If
+        - AddTSProvisionedConcurrency
+        - ProvisionedConcurrentExecutions: !FindInMap [TSProvisionedConcurrencyMapping, !Ref CriIdentifier, !Ref Environment]
+        - !Ref AWS::NoValue
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "node18"
+        Sourcemap: true
+        EntryPoints:
+          - src/handlers/dynamodb-stream-handler.ts
+        External:
+          - "@aws-sdk/*"
+
+  DynamoDbStreamFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: EnableDynamoDbStreamReplication
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${DynamoDbStreamFunction}"
+      RetentionInDays: 30
+
+  DynamoDbStreamFunctionLogGroupSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: EnableDynamoDbStreamCSLS
+    Properties:
+      DestinationArn: !If
+        - UseNewCSLSDestinationArn
+        - "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2"
+        - "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      FilterPattern: ""
+      LogGroupName: !Ref DynamoDbStreamFunctionLogGroup
+
+  DynamoDbStreamFunctionLambdaErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: EnableDynamoDbStreamCanaryAlarms
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-DynamoDbStreamFunctionLambdaErrors"
+      AlarmDescription: !Sub "Trigger an alarm when lambda errors occurs"
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub arn:aws:sns:eu-west-2:${AWS::AccountId}:platform-alarm-topic-warning-alert
+      OKActions:
+        - !Sub arn:aws:sns:eu-west-2:${AWS::AccountId}:platform-alarm-topic-warning-alert
+      InsufficientDataActions: []
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-DynamoDbStreamFunction:live"
+        - Name: ExecutedVersion
+          Value: !Sub DynamoDbStreamFunction.Version.Version
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
   DynamoTablesEncryptionKey:
     Type: AWS::KMS::Key
     Properties:
@@ -1707,6 +1854,8 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: expiryDate
         Enabled: true
+      StreamSpecification:
+        StreamViewType: NEW_AND_OLD_IMAGES
       SSESpecification: !If
         - UseCustomerManagedKey
         -
@@ -1731,6 +1880,8 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: expiryDate
         Enabled: true
+      StreamSpecification:
+        StreamViewType: NEW_AND_OLD_IMAGES
       SSESpecification: !If
         - UseCustomerManagedKey
         -

--- a/lambdas/src/handlers/dynamodb-stream-handler.ts
+++ b/lambdas/src/handlers/dynamodb-stream-handler.ts
@@ -1,0 +1,62 @@
+import { DynamoDBBatchResponse, DynamoDBStreamEvent } from "aws-lambda";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
+import { AttributeValue } from "@aws-sdk/client-dynamodb";
+import { unmarshall } from "@aws-sdk/util-dynamodb";
+import { AwsClientType, createClient } from "../common/aws-client-factory";
+import { ReplicationService } from "../services/replication-service";
+import { initOpenTelemetry } from "../common/utils/otel-setup";
+import { logger } from "@govuk-one-login/cri-logger";
+import { metrics, tracer as _tracer } from "../common/utils/power-tool";
+
+initOpenTelemetry();
+
+const dynamoDbClient = createClient(AwsClientType.DYNAMO);
+
+export class DynamoDbStreamLambda implements LambdaInterface {
+    constructor(private readonly replicationService: ReplicationService) {}
+
+    @_tracer.captureLambdaHandler({ captureResponse: false })
+    @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
+    public async handler(event: DynamoDBStreamEvent, _context: unknown): Promise<DynamoDBBatchResponse> {
+        const batchItemFailures: DynamoDBBatchResponse["batchItemFailures"] = [];
+
+        for (const record of event.Records) {
+            try {
+                const targetTable = this.replicationService.resolveTargetTable(record.eventSourceARN!);
+                const eventName = record.eventName;
+
+                if (eventName === "INSERT" || eventName === "MODIFY") {
+                    const newImage = unmarshall(
+                        record.dynamodb!.NewImage! as unknown as Record<string, AttributeValue>,
+                    );
+                    await this.replicationService.replicateItem(targetTable, newImage);
+                    logger.info(`Replicated ${eventName} event to ${targetTable}`);
+                } else if (eventName === "REMOVE") {
+                    const keys = unmarshall(record.dynamodb!.Keys! as unknown as Record<string, AttributeValue>);
+                    await this.replicationService.deleteItem(targetTable, keys);
+                    logger.info(`Deleted item from ${targetTable}`);
+                }
+            } catch (err: unknown) {
+                logger.error(`Replication error for event ${record.eventID}`, err as Error);
+                batchItemFailures.push({ itemIdentifier: record.eventID! });
+            }
+        }
+
+        return { batchItemFailures };
+    }
+}
+
+const sourceSessionTableName = process.env.SOURCE_SESSION_TABLE_NAME || "";
+const sourcePersonIdentityTableName = process.env.SOURCE_PERSON_IDENTITY_TABLE_NAME || "";
+const targetSessionTableName = process.env.TARGET_SESSION_TABLE_NAME || "";
+const targetPersonIdentityTableName = process.env.TARGET_PERSON_IDENTITY_TABLE_NAME || "";
+
+const replicationService = new ReplicationService(
+    dynamoDbClient,
+    sourceSessionTableName,
+    sourcePersonIdentityTableName,
+    targetSessionTableName,
+    targetPersonIdentityTableName,
+);
+const handlerClass = new DynamoDbStreamLambda(replicationService);
+export const lambdaHandler = handlerClass.handler.bind(handlerClass);

--- a/lambdas/src/handlers/dynamodb-stream-handler.ts
+++ b/lambdas/src/handlers/dynamodb-stream-handler.ts
@@ -4,18 +4,14 @@ import { AttributeValue } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import { AwsClientType, createClient } from "../common/aws-client-factory";
 import { ReplicationService } from "../services/replication-service";
-import { initOpenTelemetry } from "../common/utils/otel-setup";
 import { logger } from "@govuk-one-login/cri-logger";
-import { metrics, tracer as _tracer } from "../common/utils/power-tool";
-
-initOpenTelemetry();
+import { metrics } from "@govuk-one-login/cri-metrics";
 
 const dynamoDbClient = createClient(AwsClientType.DYNAMO);
 
 export class DynamoDbStreamLambda implements LambdaInterface {
     constructor(private readonly replicationService: ReplicationService) {}
 
-    @_tracer.captureLambdaHandler({ captureResponse: false })
     @metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
     public async handler(event: DynamoDBStreamEvent, _context: unknown): Promise<DynamoDBBatchResponse> {
         const batchItemFailures: DynamoDBBatchResponse["batchItemFailures"] = [];

--- a/lambdas/src/handlers/dynamodb-stream-handler.ts
+++ b/lambdas/src/handlers/dynamodb-stream-handler.ts
@@ -18,22 +18,33 @@ export class DynamoDbStreamLambda implements LambdaInterface {
 
         for (const record of event.Records) {
             try {
-                const targetTable = this.replicationService.resolveTargetTable(record.eventSourceARN!);
+                if (!record.eventSourceARN) {
+                    throw new Error("Missing eventSourceARN");
+                }
+                const targetTable = this.replicationService.resolveTargetTable(record.eventSourceARN);
                 const eventName = record.eventName;
 
+                if (!record.dynamodb) {
+                    throw new Error("Missing record.dynamodb");
+                }
+
                 if (eventName === "INSERT" || eventName === "MODIFY") {
-                    const newImage = unmarshall(
-                        record.dynamodb!.NewImage! as unknown as Record<string, AttributeValue>,
-                    );
+                    const newImage = unmarshall(record.dynamodb.NewImage as Record<string, AttributeValue>);
                     await this.replicationService.replicateItem(targetTable, newImage);
                     logger.info(`Replicated ${eventName} event to ${targetTable}`);
                 } else if (eventName === "REMOVE") {
-                    const keys = unmarshall(record.dynamodb!.Keys! as unknown as Record<string, AttributeValue>);
+                    const keys = unmarshall(record.dynamodb.Keys as Record<string, AttributeValue>);
                     await this.replicationService.deleteItem(targetTable, keys);
                     logger.info(`Deleted item from ${targetTable}`);
                 }
             } catch (err: unknown) {
-                logger.error(`Replication error for event ${record.eventID}`, err as Error);
+                if (err instanceof Error) {
+                    logger.error(`Replication error for event ${record.eventID}`, err);
+                } else {
+                    logger.error(`Replication error for event ${record.eventID}`, {
+                        error: err,
+                    });
+                }
                 batchItemFailures.push({ itemIdentifier: record.eventID! });
             }
         }

--- a/lambdas/src/services/replication-service.ts
+++ b/lambdas/src/services/replication-service.ts
@@ -1,0 +1,45 @@
+import { DynamoDBDocument, PutCommand, DeleteCommand } from "@aws-sdk/lib-dynamodb";
+import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
+
+export class ReplicationService {
+    constructor(
+        private dynamoDbClient: DynamoDBDocument,
+        private sourceSessionTableName: string,
+        private sourcePersonIdentityTableName: string,
+        private targetSessionTableName: string,
+        private targetPersonIdentityTableName: string,
+    ) {}
+
+    public resolveTargetTable(eventSourceArn: string): string {
+        // Stream ARN format: arn:aws:dynamodb:<region>:<account>:table/<table-name>/stream/<timestamp>
+        const sourceTableName = eventSourceArn.split("/")[1];
+
+        if (sourceTableName === this.sourceSessionTableName) {
+            return this.targetSessionTableName;
+        }
+        if (sourceTableName === this.sourcePersonIdentityTableName) {
+            return this.targetPersonIdentityTableName;
+        }
+
+        throw new Error(
+            `Unknown source table: ${sourceTableName}. ` +
+                `Expected '${this.sourceSessionTableName}' or '${this.sourcePersonIdentityTableName}'.`,
+        );
+    }
+
+    public async replicateItem(targetTable: string, item: Record<string, NativeAttributeValue>): Promise<void> {
+        const putCommand = new PutCommand({
+            TableName: targetTable,
+            Item: item,
+        });
+        await this.dynamoDbClient.send(putCommand);
+    }
+
+    public async deleteItem(targetTable: string, key: Record<string, NativeAttributeValue>): Promise<void> {
+        const deleteCommand = new DeleteCommand({
+            TableName: targetTable,
+            Key: key,
+        });
+        await this.dynamoDbClient.send(deleteCommand);
+    }
+}

--- a/lambdas/src/services/replication-service.ts
+++ b/lambdas/src/services/replication-service.ts
@@ -3,11 +3,11 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
 export class ReplicationService {
     constructor(
-        private dynamoDbClient: DynamoDBDocument,
-        private sourceSessionTableName: string,
-        private sourcePersonIdentityTableName: string,
-        private targetSessionTableName: string,
-        private targetPersonIdentityTableName: string,
+        private readonly dynamoDbClient: DynamoDBDocument,
+        private readonly sourceSessionTableName: string,
+        private readonly sourcePersonIdentityTableName: string,
+        private readonly targetSessionTableName: string,
+        private readonly targetPersonIdentityTableName: string,
     ) {}
 
     public resolveTargetTable(eventSourceArn: string): string {

--- a/lambdas/tests/unit/handlers/dynamodb-stream-handler.test.ts
+++ b/lambdas/tests/unit/handlers/dynamodb-stream-handler.test.ts
@@ -1,0 +1,203 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { Context, DynamoDBStreamEvent } from "aws-lambda";
+import { DynamoDbStreamLambda } from "../../../src/handlers/dynamodb-stream-handler";
+import { ReplicationService } from "../../../src/services/replication-service";
+
+jest.mock("@aws-sdk/lib-dynamodb");
+jest.mock("@aws-sdk/client-dynamodb");
+jest.mock("@aws-lambda-powertools/metrics");
+jest.mock("@aws-lambda-powertools/logger");
+jest.mock("../../../src/services/replication-service");
+
+const SOURCE_SESSION_ARN =
+    "arn:aws:dynamodb:eu-west-2:123456789012:table/session-stack-a/stream/2024-01-01T00:00:00.000";
+const SOURCE_PERSON_IDENTITY_ARN =
+    "arn:aws:dynamodb:eu-west-2:123456789012:table/person-identity-stack-a/stream/2024-01-01T00:00:00.000";
+
+function makeStreamEvent(records: DynamoDBStreamEvent["Records"]): DynamoDBStreamEvent {
+    return { Records: records };
+}
+
+function makeRecord(overrides: {
+    eventName: "INSERT" | "MODIFY" | "REMOVE";
+    eventSourceARN: string;
+    newImage?: Record<string, { S?: string; N?: string }>;
+    keys?: Record<string, { S?: string }>;
+    eventID?: string;
+}): DynamoDBStreamEvent["Records"][0] {
+    const record: DynamoDBStreamEvent["Records"][0] = {
+        eventID: overrides.eventID || "test-event-id",
+        eventName: overrides.eventName,
+        eventSourceARN: overrides.eventSourceARN,
+        eventVersion: "1.1",
+        eventSource: "aws:dynamodb",
+        awsRegion: "eu-west-2",
+        dynamodb: {
+            Keys: overrides.keys || { sessionId: { S: "sess-123" } },
+        },
+    };
+    if (overrides.newImage) {
+        record.dynamodb!.NewImage = overrides.newImage;
+    }
+    return record;
+}
+
+describe("DynamoDbStreamLambda", () => {
+    let dynamoDbStreamLambda: DynamoDbStreamLambda;
+    let logger: jest.MockedObjectDeep<typeof Logger>;
+    let replicationService: jest.MockedObjectDeep<typeof ReplicationService>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        logger = jest.mocked(Logger);
+        replicationService = jest.mocked(ReplicationService);
+
+        jest.spyOn(logger.prototype, "error").mockImplementation();
+        jest.spyOn(logger.prototype, "info").mockImplementation();
+
+        jest.spyOn(replicationService.prototype, "resolveTargetTable").mockReturnValue("session-stack-b");
+        jest.spyOn(replicationService.prototype, "replicateItem").mockResolvedValue(undefined);
+        jest.spyOn(replicationService.prototype, "deleteItem").mockResolvedValue(undefined);
+
+        dynamoDbStreamLambda = new DynamoDbStreamLambda(replicationService.prototype);
+    });
+
+    it("should replicate INSERT events to the target table", async () => {
+        const event = makeStreamEvent([
+            makeRecord({
+                eventName: "INSERT",
+                eventSourceARN: SOURCE_SESSION_ARN,
+                newImage: {
+                    sessionId: { S: "sess-123" },
+                    clientId: { S: "client-abc" },
+                    expiryDate: { N: "1700000000" },
+                },
+            }),
+        ]);
+
+        const result = await dynamoDbStreamLambda.handler(event, {} as Context);
+
+        expect(result.batchItemFailures).toHaveLength(0);
+        expect(replicationService.prototype.resolveTargetTable).toHaveBeenCalledWith(SOURCE_SESSION_ARN);
+        expect(replicationService.prototype.replicateItem).toHaveBeenCalledWith(
+            "session-stack-b",
+            expect.objectContaining({ sessionId: "sess-123" }),
+        );
+    });
+
+    it("should replicate MODIFY events to the target table", async () => {
+        jest.spyOn(replicationService.prototype, "resolveTargetTable").mockReturnValue("person-identity-stack-b");
+        const event = makeStreamEvent([
+            makeRecord({
+                eventName: "MODIFY",
+                eventSourceARN: SOURCE_PERSON_IDENTITY_ARN,
+                newImage: { sessionId: { S: "sess-456" } },
+            }),
+        ]);
+
+        const result = await dynamoDbStreamLambda.handler(event, {} as Context);
+
+        expect(result.batchItemFailures).toHaveLength(0);
+        expect(replicationService.prototype.replicateItem).toHaveBeenCalledTimes(1);
+    });
+
+    it("should delete items on REMOVE events", async () => {
+        const event = makeStreamEvent([
+            makeRecord({
+                eventName: "REMOVE",
+                eventSourceARN: SOURCE_SESSION_ARN,
+                keys: { sessionId: { S: "sess-789" } },
+            }),
+        ]);
+
+        const result = await dynamoDbStreamLambda.handler(event, {} as Context);
+
+        expect(result.batchItemFailures).toHaveLength(0);
+        expect(replicationService.prototype.deleteItem).toHaveBeenCalledWith(
+            "session-stack-b",
+            expect.objectContaining({ sessionId: "sess-789" }),
+        );
+    });
+
+    it("should process multiple records in a single batch", async () => {
+        const event = makeStreamEvent([
+            makeRecord({
+                eventName: "INSERT",
+                eventSourceARN: SOURCE_SESSION_ARN,
+                newImage: { sessionId: { S: "sess-1" } },
+                eventID: "evt-1",
+            }),
+            makeRecord({
+                eventName: "INSERT",
+                eventSourceARN: SOURCE_PERSON_IDENTITY_ARN,
+                newImage: { sessionId: { S: "sess-2" } },
+                eventID: "evt-2",
+            }),
+            makeRecord({
+                eventName: "REMOVE",
+                eventSourceARN: SOURCE_SESSION_ARN,
+                keys: { sessionId: { S: "sess-3" } },
+                eventID: "evt-3",
+            }),
+        ]);
+
+        const result = await dynamoDbStreamLambda.handler(event, {} as Context);
+
+        expect(result.batchItemFailures).toHaveLength(0);
+        expect(replicationService.prototype.replicateItem).toHaveBeenCalledTimes(2);
+        expect(replicationService.prototype.deleteItem).toHaveBeenCalledTimes(1);
+    });
+
+    it("should report individual record failures without failing the batch", async () => {
+        jest.spyOn(replicationService.prototype, "replicateItem")
+            .mockResolvedValueOnce(undefined)
+            .mockRejectedValueOnce(new Error("Throttled"))
+            .mockResolvedValueOnce(undefined);
+
+        const event = makeStreamEvent([
+            makeRecord({
+                eventName: "INSERT",
+                eventSourceARN: SOURCE_SESSION_ARN,
+                newImage: { sessionId: { S: "sess-1" } },
+                eventID: "evt-1",
+            }),
+            makeRecord({
+                eventName: "INSERT",
+                eventSourceARN: SOURCE_SESSION_ARN,
+                newImage: { sessionId: { S: "sess-2" } },
+                eventID: "evt-2",
+            }),
+            makeRecord({
+                eventName: "INSERT",
+                eventSourceARN: SOURCE_SESSION_ARN,
+                newImage: { sessionId: { S: "sess-3" } },
+                eventID: "evt-3",
+            }),
+        ]);
+
+        const result = await dynamoDbStreamLambda.handler(event, {} as Context);
+
+        expect(result.batchItemFailures).toHaveLength(1);
+        expect(result.batchItemFailures[0].itemIdentifier).toBe("evt-2");
+        expect(replicationService.prototype.replicateItem).toHaveBeenCalledTimes(3);
+    });
+
+    it("should log errors with the event ID", async () => {
+        const errorSpy = jest.spyOn(logger.prototype, "error");
+        jest.spyOn(replicationService.prototype, "replicateItem").mockRejectedValueOnce(new Error("DynamoDB error"));
+
+        const event = makeStreamEvent([
+            makeRecord({
+                eventName: "INSERT",
+                eventSourceARN: SOURCE_SESSION_ARN,
+                newImage: { sessionId: { S: "sess-1" } },
+                eventID: "evt-fail",
+            }),
+        ]);
+
+        await dynamoDbStreamLambda.handler(event, {} as Context);
+
+        expect(errorSpy).toHaveBeenCalledWith("Replication error for event evt-fail", expect.any(Error));
+    });
+});

--- a/lambdas/tests/unit/handlers/dynamodb-stream-handler.test.ts
+++ b/lambdas/tests/unit/handlers/dynamodb-stream-handler.test.ts
@@ -7,7 +7,7 @@ import { logger } from "@govuk-one-login/cri-logger";
 
 vi.mock("@aws-sdk/lib-dynamodb");
 vi.mock("@aws-sdk/client-dynamodb");
-vi.mock("@aws-lambda-powertools/metrics");
+vi.mock("@govuk-one-login/cri-metrics");
 vi.mock("../../../src/services/replication-service");
 vi.mock("@govuk-one-login/cri-logger", () => ({
     logger: {

--- a/lambdas/tests/unit/handlers/dynamodb-stream-handler.test.ts
+++ b/lambdas/tests/unit/handlers/dynamodb-stream-handler.test.ts
@@ -1,13 +1,20 @@
-import { Logger } from "@aws-lambda-powertools/logger";
 import { Context, DynamoDBStreamEvent } from "aws-lambda";
 import { DynamoDbStreamLambda } from "../../../src/handlers/dynamodb-stream-handler";
 import { ReplicationService } from "../../../src/services/replication-service";
+import { beforeEach, describe, expect, it, Mock, MockedObject, vi } from "vitest";
+import { LogItemMessage, LogItemExtraInput } from "@aws-lambda-powertools/logger/lib/cjs/types/Logger";
+import { logger } from "@govuk-one-login/cri-logger";
 
-jest.mock("@aws-sdk/lib-dynamodb");
-jest.mock("@aws-sdk/client-dynamodb");
-jest.mock("@aws-lambda-powertools/metrics");
-jest.mock("@aws-lambda-powertools/logger");
-jest.mock("../../../src/services/replication-service");
+vi.mock("@aws-sdk/lib-dynamodb");
+vi.mock("@aws-sdk/client-dynamodb");
+vi.mock("@aws-lambda-powertools/metrics");
+vi.mock("../../../src/services/replication-service");
+vi.mock("@govuk-one-login/cri-logger", () => ({
+    logger: {
+        info: vi.fn(),
+        error: vi.fn(),
+    },
+}));
 
 const SOURCE_SESSION_ARN =
     "arn:aws:dynamodb:eu-west-2:123456789012:table/session-stack-a/stream/2024-01-01T00:00:00.000";
@@ -44,21 +51,20 @@ function makeRecord(overrides: {
 
 describe("DynamoDbStreamLambda", () => {
     let dynamoDbStreamLambda: DynamoDbStreamLambda;
-    let logger: jest.MockedObjectDeep<typeof Logger>;
-    let replicationService: jest.MockedObjectDeep<typeof ReplicationService>;
+    let replicationService: MockedObject<typeof ReplicationService>;
+    let errorSpy: Mock<(input: LogItemMessage, ...extraInput: LogItemExtraInput) => void>;
 
     beforeEach(() => {
-        jest.clearAllMocks();
+        vi.clearAllMocks();
 
-        logger = jest.mocked(Logger);
-        replicationService = jest.mocked(ReplicationService);
+        replicationService = vi.mocked(ReplicationService);
 
-        jest.spyOn(logger.prototype, "error").mockImplementation();
-        jest.spyOn(logger.prototype, "info").mockImplementation();
+        errorSpy = vi.spyOn(logger, "error");
+        vi.spyOn(logger, "info");
 
-        jest.spyOn(replicationService.prototype, "resolveTargetTable").mockReturnValue("session-stack-b");
-        jest.spyOn(replicationService.prototype, "replicateItem").mockResolvedValue(undefined);
-        jest.spyOn(replicationService.prototype, "deleteItem").mockResolvedValue(undefined);
+        vi.spyOn(replicationService.prototype, "resolveTargetTable").mockReturnValue("session-stack-b");
+        vi.spyOn(replicationService.prototype, "replicateItem").mockResolvedValue(undefined);
+        vi.spyOn(replicationService.prototype, "deleteItem").mockResolvedValue(undefined);
 
         dynamoDbStreamLambda = new DynamoDbStreamLambda(replicationService.prototype);
     });
@@ -87,7 +93,7 @@ describe("DynamoDbStreamLambda", () => {
     });
 
     it("should replicate MODIFY events to the target table", async () => {
-        jest.spyOn(replicationService.prototype, "resolveTargetTable").mockReturnValue("person-identity-stack-b");
+        vi.spyOn(replicationService.prototype, "resolveTargetTable").mockReturnValue("person-identity-stack-b");
         const event = makeStreamEvent([
             makeRecord({
                 eventName: "MODIFY",
@@ -150,7 +156,7 @@ describe("DynamoDbStreamLambda", () => {
     });
 
     it("should report individual record failures without failing the batch", async () => {
-        jest.spyOn(replicationService.prototype, "replicateItem")
+        vi.spyOn(replicationService.prototype, "replicateItem")
             .mockResolvedValueOnce(undefined)
             .mockRejectedValueOnce(new Error("Throttled"))
             .mockResolvedValueOnce(undefined);
@@ -184,8 +190,7 @@ describe("DynamoDbStreamLambda", () => {
     });
 
     it("should log errors with the event ID", async () => {
-        const errorSpy = jest.spyOn(logger.prototype, "error");
-        jest.spyOn(replicationService.prototype, "replicateItem").mockRejectedValueOnce(new Error("DynamoDB error"));
+        vi.spyOn(replicationService.prototype, "replicateItem").mockRejectedValueOnce(new Error("DynamoDB error"));
 
         const event = makeStreamEvent([
             makeRecord({

--- a/lambdas/tests/unit/services/replication-service.test.ts
+++ b/lambdas/tests/unit/services/replication-service.test.ts
@@ -1,0 +1,96 @@
+import { ReplicationService } from "../../../src/services/replication-service";
+import { DynamoDBDocument, PutCommand, DeleteCommand } from "@aws-sdk/lib-dynamodb";
+
+jest.mock("@aws-sdk/lib-dynamodb", () => {
+    return {
+        __esModule: true,
+        ...jest.requireActual("@aws-sdk/lib-dynamodb"),
+        PutCommand: jest.fn(),
+        DeleteCommand: jest.fn(),
+    };
+});
+
+describe("replication-service", () => {
+    let replicationService: ReplicationService;
+
+    const mockDynamoDbClient = jest.mocked(DynamoDBDocument);
+    const mockPutCommand = jest.mocked(PutCommand);
+    const mockDeleteCommand = jest.mocked(DeleteCommand);
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        replicationService = new ReplicationService(
+            mockDynamoDbClient.prototype,
+            "session-stack-a",
+            "person-identity-stack-a",
+            "session-stack-b",
+            "person-identity-stack-b",
+        );
+        const impl = () => {
+            const mockPromise = new Promise<unknown>((resolve) => {
+                resolve({});
+            });
+            return jest.fn().mockImplementation(() => {
+                return mockPromise;
+            });
+        };
+        mockDynamoDbClient.prototype.send = impl();
+    });
+
+    describe("resolveTargetTable", () => {
+        it("should resolve session table ARN to the target session table", () => {
+            const arn = "arn:aws:dynamodb:eu-west-2:123456789012:table/session-stack-a/stream/2024-01-01T00:00:00.000";
+
+            const result = replicationService.resolveTargetTable(arn);
+
+            expect(result).toBe("session-stack-b");
+        });
+
+        it("should resolve person identity table ARN to the target person identity table", () => {
+            const arn =
+                "arn:aws:dynamodb:eu-west-2:123456789012:table/person-identity-stack-a/stream/2024-01-01T00:00:00.000";
+
+            const result = replicationService.resolveTargetTable(arn);
+
+            expect(result).toBe("person-identity-stack-b");
+        });
+
+        it("should throw an error for an unknown source table", () => {
+            const arn = "arn:aws:dynamodb:eu-west-2:123456789012:table/unknown-table/stream/2024-01-01T00:00:00.000";
+
+            expect(() => replicationService.resolveTargetTable(arn)).toThrow(
+                "Unknown source table: unknown-table. Expected 'session-stack-a' or 'person-identity-stack-a'.",
+            );
+        });
+    });
+
+    describe("replicateItem", () => {
+        it("should put the item into the target table", async () => {
+            const targetTable = "session-stack-b";
+            const item = { sessionId: "sess-123", clientId: "client-abc", expiryDate: 1700000000 };
+
+            await replicationService.replicateItem(targetTable, item);
+
+            expect(mockPutCommand).toHaveBeenCalledWith({
+                TableName: targetTable,
+                Item: item,
+            });
+            expect(mockDynamoDbClient.prototype.send).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("deleteItem", () => {
+        it("should delete the item from the target table", async () => {
+            const targetTable = "session-stack-b";
+            const key = { sessionId: "sess-789" };
+
+            await replicationService.deleteItem(targetTable, key);
+
+            expect(mockDeleteCommand).toHaveBeenCalledWith({
+                TableName: targetTable,
+                Key: key,
+            });
+            expect(mockDynamoDbClient.prototype.send).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/lambdas/tests/unit/services/replication-service.test.ts
+++ b/lambdas/tests/unit/services/replication-service.test.ts
@@ -1,24 +1,26 @@
 import { ReplicationService } from "../../../src/services/replication-service";
 import { DynamoDBDocument, PutCommand, DeleteCommand } from "@aws-sdk/lib-dynamodb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-jest.mock("@aws-sdk/lib-dynamodb", () => {
+vi.mock("@aws-sdk/lib-dynamodb", async () => {
+    const actual = await vi.importActual<typeof import("@aws-sdk/lib-dynamodb")>("@aws-sdk/lib-dynamodb");
     return {
         __esModule: true,
-        ...jest.requireActual("@aws-sdk/lib-dynamodb"),
-        PutCommand: jest.fn(),
-        DeleteCommand: jest.fn(),
+        ...actual,
+        PutCommand: vi.fn(),
+        DeleteCommand: vi.fn(),
     };
 });
 
 describe("replication-service", () => {
     let replicationService: ReplicationService;
 
-    const mockDynamoDbClient = jest.mocked(DynamoDBDocument);
-    const mockPutCommand = jest.mocked(PutCommand);
-    const mockDeleteCommand = jest.mocked(DeleteCommand);
+    const mockDynamoDbClient = vi.mocked(DynamoDBDocument);
+    const mockPutCommand = vi.mocked(PutCommand);
+    const mockDeleteCommand = vi.mocked(DeleteCommand);
 
     beforeEach(() => {
-        jest.resetAllMocks();
+        vi.resetAllMocks();
         replicationService = new ReplicationService(
             mockDynamoDbClient.prototype,
             "session-stack-a",
@@ -30,7 +32,7 @@ describe("replication-service", () => {
             const mockPromise = new Promise<unknown>((resolve) => {
                 resolve({});
             });
-            return jest.fn().mockImplementation(() => {
+            return vi.fn().mockImplementation(() => {
                 return mockPromise;
             });
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -334,56 +334,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.1012.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1012.0.tgz",
-      "integrity": "sha512-LTQtg7+aFF4aOex9Q68lOPxlvtneml8OGW3wDE4z44vT+XdmKRQf3+A8ROig++v7LwAQl5vfI40AMs5zJZc7GQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.21",
-        "@aws-sdk/credential-provider-node": "^3.972.22",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.22",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.26",
-        "@smithy/middleware-retry": "^4.4.43",
-        "@smithy/middleware-serde": "^4.2.15",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.42",
-        "@smithy/util-defaults-mode-node": "^4.2.45",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1048.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1048.0.tgz",
@@ -3340,19 +3290,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-waiter": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
-      "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9125,104 +9062,6 @@
         "@smithy/types": "^4.14.1",
         "@smithy/url-parser": "^4.2.14",
         "@smithy/util-endpoints": "^3.4.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "test-resources/node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1012.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1012.0.tgz",
-      "integrity": "sha512-9iy4ngJYXRtxEtHL8RFSV+hTr2Rx67qxRhh8wOE3tREokKUFMBwrvb0D0JIBcK76qqZvUanycSpNQhYm/AuWwA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.21",
-        "@aws-sdk/credential-provider-node": "^3.972.22",
-        "@aws-sdk/dynamodb-codec": "^3.972.22",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.8",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.22",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.26",
-        "@smithy/middleware-retry": "^4.4.43",
-        "@smithy/middleware-serde": "^4.2.15",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.42",
-        "@smithy/util-defaults-mode-node": "^4.2.45",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.13",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "test-resources/node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.10.tgz",
-      "integrity": "sha512-cdmvh+mmVWFKNhqFv/axpjJOYyaCgw+zta93IOv9sXKZPoL1m0XVhSI/Y7MGKLeVHUkG+ULVZy+q5AEAGivSDw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@smithy/core": "^3.24.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "test-resources/node_modules/@aws-sdk/credential-providers": {
-      "version": "3.1012.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1012.0.tgz",
-      "integrity": "sha512-sXXj6aiqDkwNSfsp2Qh89vX4BQwlI04MaHvynfxYkPWe93FDmD9Jy+qidsb2XU6i9oWLL6ptALgGFQwBzV0/cQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.1012.0",
-        "@aws-sdk/core": "^3.973.21",
-        "@aws-sdk/credential-provider-cognito-identity": "^3.972.14",
-        "@aws-sdk/credential-provider-env": "^3.972.19",
-        "@aws-sdk/credential-provider-http": "^3.972.21",
-        "@aws-sdk/credential-provider-ini": "^3.972.21",
-        "@aws-sdk/credential-provider-login": "^3.972.21",
-        "@aws-sdk/credential-provider-node": "^3.972.22",
-        "@aws-sdk/credential-provider-process": "^3.972.19",
-        "@aws-sdk/credential-provider-sso": "^3.972.21",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.21",
-        "@aws-sdk/nested-clients": "^3.996.11",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.12",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {


### PR DESCRIPTION
## Proposed changes

Note: Not to be merged until the outcome of https://govukverify.atlassian.net/browse/OJ-3717 is determined.

### What changed

Added Stream functionality from common-lambdas -> OAuthCommon databases. 
Added the `EnableDynamoDbStream` mapping as the feature flag for this. 

### Why did it change

This allows us to replicate the data from the common-lambdas databases to OAuthCommon databases during the migration. 

### Issue tracking
- [OJ-3554](https://govukverify.atlassian.net/browse/OJ-3554)


[OJ-3554]: https://govukverify.atlassian.net/browse/OJ-3554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ