### PR TITLE
OJ-3596: Use resolve for common/oauth stack name

### DIFF
--- a/test-resources/README.md
+++ b/test-resources/README.md
@@ -10,3 +10,4 @@ To start using the test resources to an account of your choosing follow these st
 2. Add `{CRI}_ARTIFACTS_BUCKET_NAME`, `{CRI}_ENABLED`, `{CRI}_ROLE_ARN`, `{CRI}_SIGNING_PROFILE_NAME` environment variables to github for the relevant `test-resources-{env}` environments
 3. Update the matrix in [package-test-resources workflow](../.github/workflows/package-test-resources.yml) to include your CRI in the `cri` and `include` sections so that it works for your CRI
 4. Update the `TestHarnessUrl` mapping in [the template file](./infrastructure/template.yaml) to include your CRI and the dev, build and staging domains. This will be used to created a test harness domain for your account
+5. Ensure the account you are deploying to has the SSM param `/common-cri/oauth-common/stack-name`, containing the oauth/common stackname in use in that account. 

--- a/test-resources/deploy.sh
+++ b/test-resources/deploy.sh
@@ -31,7 +31,7 @@ sam deploy --stack-name "$stack_name" \
   cri:stack-type=localdev \
   --parameter-overrides \
   Environment=localdev \
-  ${common_stack_name:+CommonStackName=$common_stack_name} \
+  ${common_stack_name:+CommonStackNameOverride=$common_stack_name} \
   ${test_txma_stack:+TxmaStackName=$test_txma_stack} \
   ${core_infra_stack:+CoreInfraStackName=$core_infra_stack}
 

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -30,10 +30,10 @@ Parameters:
     Type: String
     Default: "cri-vpc"
     Description: The name of the VPC stack deployed.
-  CommonStackName:
-    Description: "The name of the stack containing the common CRI lambdas/infra"
+  CommonStackNameOverride:
     Type: String
-    Default: common-cri-api
+    Description: "Optional override of the oauth/common stack name, only needed for localdev. SSM param will be used by default /common-cri/oauth-common/stack-name"
+    Default: ""
   IsPreview:
     Description: "Set to true for preview stack deployments to use a per-stack SNS relay queue instead of attaching directly to the TXMA queue"
     Type: String
@@ -128,6 +128,8 @@ Conditions:
   IsDevOrBuildEnviroment: !Or
     - !Equals [!Ref Environment, dev]
     - !Equals [!Ref Environment, build]
+  
+  UseCommonStackNameOverride: !Not [!Equals [!Ref CommonStackNameOverride, ""]]
 
 Globals:
   Function:
@@ -151,7 +153,10 @@ Globals:
         NODE_OPTIONS: --enable-source-maps
         POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
         POWERTOOLS_LOG_LEVEL: DEBUG
-        COMMON_STACK_NAME: !Ref CommonStackName
+        COMMON_STACK_NAME: !If
+            - UseCommonStackNameOverride
+            - !Ref CommonStackNameOverride
+            - "{{resolve:ssm:/common-cri/oauth-common/stack-name}}"
         AWS_STACK_NAME: !Sub ${AWS::StackName}
     AutoPublishAlias: live
     ProvisionedConcurrencyConfig: !If
@@ -193,7 +198,10 @@ Resources:
                 - ssm:GetParameters
                 - ssm:GetParameter
               Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/clients/*/jwtAuthentication/*"
+                - !If
+                  - UseCommonStackNameOverride
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackNameOverride}/clients/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/{{resolve:ssm:/common-cri/oauth-common/stack-name}}/clients/*"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/test-resources/ipv-core-stub-aws-headless/privateSigningKey"
 
 
@@ -241,7 +249,10 @@ Resources:
                 - ssm:GetParameters
                 - ssm:GetParameter
               Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/clients/*/jwtAuthentication/*"
+                - !If
+                  - UseCommonStackNameOverride
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackNameOverride}/clients/*/jwtAuthentication/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/{{resolve:ssm:/common-cri/oauth-common/stack-name}}/clients/*/jwtAuthentication/*"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/test-resources/ipv-core-stub-aws-headless/privateSigningKey"
 
   StartFunctionLogGroup:
@@ -277,7 +288,10 @@ Resources:
           CORE_INFRASTRUCTURE: !Sub "${CoreInfraStackName}"
       Policies:
         - DynamoDBReadPolicy:
-            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+            TableName: !If
+              - UseCommonStackNameOverride
+              - !Sub "{{resolve:ssm:/${CommonStackNameOverride}/SessionTableName}}"
+              - !Sub "{{resolve:ssm:/common-cri/oauth-common/stack-name}}/SessionTableName}}"
         - Statement:
             - Effect: Allow
               Action:
@@ -285,7 +299,10 @@ Resources:
                 - ssm:GetParameters
                 - ssm:GetParameter
               Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/clients/*/jwtAuthentication/*"
+                - !If
+                  - UseCommonStackNameOverride
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackNameOverride}/clients/*/jwtAuthentication/*"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/{{resolve:ssm:/common-cri/oauth-common/stack-name}}/clients/*/jwtAuthentication/*"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/test-resources/ipv-core-stub-aws-headless/privateSigningKey"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/test-resources/apiKey"
             - Effect: Allow
@@ -627,4 +644,7 @@ Outputs:
     Description: Common stack name used by the test resources
     Export:
       Name: !Sub ${AWS::StackName}-CommonStackName
-    Value: !Ref CommonStackName
+    Value: !If
+      - UseCommonStackNameOverride
+      - !Ref CommonStackNameOverride
+      - "{{resolve:ssm:/common-cri/oauth-common/stack-name}}"


### PR DESCRIPTION
## Proposed changes

### What changed

- Change `CommonStackName` CF parameter to `CommonStackNameOverride` - This is primarily for `localdev` deploys. 
- Where we want to use `CommonStackName`, instead use `{{resolve:ssm:/common-cri/oauth-common/stack-name}}` 

### Why did it change

Initial reverted PR: https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/668

When deployed through our pipelines to existing stacks, even if we change CF parameter defaults, they do not change/update if the parameter already exists on the stack. 

### Issue tracking

- [OJ-3596](https://govukverify.atlassian.net/browse/OJ-3596)

[OJ-3596]: https://govukverify.atlassian.net/browse/OJ-3596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ