### PR TITLE
OJ-3654: Dependency fixes & upgrades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1430,12 +1430,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
-      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.5.8",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2004,6 +2005,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2021,6 +2023,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2038,6 +2041,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2055,6 +2059,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2086,6 +2091,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2103,6 +2109,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2120,6 +2127,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2137,6 +2145,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2154,6 +2163,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2171,6 +2181,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2188,6 +2199,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2205,6 +2217,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2222,6 +2235,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2239,6 +2253,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2256,6 +2271,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2273,6 +2289,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2306,6 +2323,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2323,6 +2341,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2340,6 +2359,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2357,6 +2377,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2374,6 +2395,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2391,6 +2413,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2408,6 +2431,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2425,6 +2449,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3903,6 +3928,18 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5791,9 +5828,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -9174,33 +9211,36 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -12925,15 +12965,16 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14317,15 +14358,16 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -14587,6 +14629,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -14604,6 +14647,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6341,13 +6341,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "dev": true,
@@ -14909,19 +14902,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "dev": true,
@@ -15513,8 +15493,7 @@
         "crypto": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "esbuild": "0.25.1",
-        "jose": "6.2.2",
-        "uuid": "9.0.1"
+        "jose": "6.2.2"
       },
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "3.1012.0",
@@ -15522,7 +15501,6 @@
         "@aws-sdk/types": "3.973.6",
         "@types/aws-lambda": "^8.10.145",
         "@types/jest": "^29.5.13",
-        "@types/uuid": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "^6.11.0",
         "@typescript-eslint/parser": "^6.11.0",
         "@vitest/coverage-v8": "4.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7749,13 +7749,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
-      "license": "ISC"
-    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "dev": true,
@@ -15490,7 +15483,6 @@
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
         "aws-sdk-client-mock": "4.1.0",
-        "crypto": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "esbuild": "0.25.1",
         "jose": "6.2.2"

--- a/test-resources/headless-core-stub/lambdas/callback/src/services/private-key-jwt-helper.ts
+++ b/test-resources/headless-core-stub/lambdas/callback/src/services/private-key-jwt-helper.ts
@@ -1,5 +1,5 @@
 import { JWK, JWTPayload } from "jose";
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import { signJwt } from "../../../../utils/src/crypto/signer";
 import { getHashedKid } from "../../../../utils/src/hashing";
 
@@ -15,7 +15,7 @@ export const generatePrivateJwtParams = async (
         sub: clientId,
         aud: audience,
         exp: msToSeconds(Date.now() + 5 * 60 * 1000),
-        jti: uuidv4(),
+        jti: randomUUID(),
     };
 
     const jwtHeader = {

--- a/test-resources/headless-core-stub/lambdas/start/src/services/jwt-claims-set-service.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/services/jwt-claims-set-service.ts
@@ -2,7 +2,7 @@ import { IssuerAuthorizationRequestSchema } from "@govuk-one-login/data-vocab-sc
 import { IssuerAuthorizationRequestClass } from "@govuk-one-login/data-vocab/credentials";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import { ClaimsSetOverrides } from "../types/claims-set-overrides";
 import { JWTClaimsSet } from "../types/jwt-claims-set";
 import { logger } from "../start-handler";
@@ -35,7 +35,7 @@ export const generateJwtClaimsSet = async (overrides: ClaimsSetOverrides, ssmPar
     const now = Date.now();
     return {
         iss: issuer,
-        sub: overrides.sub || "urn:fdc:gov.uk:" + uuidv4(),
+        sub: overrides.sub || "urn:fdc:gov.uk:" + randomUUID(),
         aud: audience,
         iat: overrides.iat || msToSeconds(now),
         exp: overrides.exp || msToSeconds(now + 5 * 60 * 1000),

--- a/test-resources/headless-core-stub/lambdas/start/src/services/jwt-claims-set-service.ts
+++ b/test-resources/headless-core-stub/lambdas/start/src/services/jwt-claims-set-service.ts
@@ -44,7 +44,7 @@ export const generateJwtClaimsSet = async (overrides: ClaimsSetOverrides, ssmPar
         client_id: overrides.client_id,
         redirect_uri: redirectUri,
         state,
-        govuk_signin_journey_id: overrides.govuk_signin_journey_id || uuidv4(),
+        govuk_signin_journey_id: overrides.govuk_signin_journey_id || randomUUID(),
         shared_claims: overrides.shared_claims != null ? overrides.shared_claims : defaultClaims,
         ...(overrides.evidence_requested && { evidence_requested: overrides.evidence_requested }),
         ...(overrides.context && { context: overrides.context }),

--- a/test-resources/headless-core-stub/lambdas/start/tests/services/jwt-claims-set-service.test.ts
+++ b/test-resources/headless-core-stub/lambdas/start/tests/services/jwt-claims-set-service.test.ts
@@ -1,4 +1,3 @@
-import { validate as isValidUUID } from "uuid";
 import { HeadlessCoreStubError } from "../../../../utils/src/errors/headless-core-stub-error";
 import {
     generateJwtClaimsSet,
@@ -8,6 +7,8 @@ import {
 import { ClaimsSetOverrides } from "../../src/types/claims-set-overrides";
 import { TestData } from "../../../../utils/tests/test-data";
 import { base64Decode } from "../../../../utils/src/base64";
+
+const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 describe("jwt-claims-set-service", () => {
     describe("parseJwtClaimsSetOverrides", () => {
@@ -105,7 +106,7 @@ describe("jwt-claims-set-service", () => {
             const before = Math.round(Date.now() / 1000);
             const jwtClaimsSet = await generateJwtClaimsSet(overrides, ssmParameters);
             const after = Math.round(Date.now() / 1000);
-            expect(isValidUUID(jwtClaimsSet.govuk_signin_journey_id || "")).toBeTruthy();
+            expect(uuidRegex.test(jwtClaimsSet.govuk_signin_journey_id || "")).toBeTruthy();
             expect(JSON.parse(base64Decode(jwtClaimsSet.state))).toEqual({
                 aud: ssmParameters.audience,
                 redirect_uri: ssmParameters.redirectUri,

--- a/test-resources/package.json
+++ b/test-resources/package.json
@@ -32,8 +32,7 @@
         "crypto": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "esbuild": "0.25.1",
-        "jose": "6.2.2",
-        "uuid": "9.0.1"
+        "jose": "6.2.2"
     },
     "devDependencies": {
         "@aws-sdk/client-dynamodb": "3.1012.0",
@@ -41,7 +40,6 @@
         "@aws-sdk/types": "3.973.6",
         "@types/aws-lambda": "^8.10.145",
         "@types/jest": "^29.5.13",
-        "@types/uuid": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "^6.11.0",
         "@typescript-eslint/parser": "^6.11.0",
         "@vitest/coverage-v8": "4.1.3",

--- a/test-resources/package.json
+++ b/test-resources/package.json
@@ -29,7 +29,6 @@
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
         "aws-sdk-client-mock": "4.1.0",
-        "crypto": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "esbuild": "0.25.1",
         "jose": "6.2.2"


### PR DESCRIPTION
## Proposed changes

### What changed

- Ran `npm audit fix`
- Replaced `"uuid"` dependency with native Node functionality
- Removed `"crypto"` module from package.json as its functionality is bundled in node

### Why did it change

- Fixing current advisories
  - https://github.com/govuk-one-login/ipv-cri-common-lambdas/security/dependabot/107
  - https://github.com/govuk-one-login/ipv-cri-common-lambdas/security/dependabot/108
  - https://github.com/govuk-one-login/ipv-cri-common-lambdas/security/dependabot/109
- Removing unnecessary packages to reduce future vulnerability exposure

### Issue tracking

- OJ-3654

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
