### PR TITLE
SPT-1933: Make the VPC stack name configurable

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -57,6 +57,10 @@ Parameters:
     Description: The topic to publish notification and sns alerts
     Type: String
     Default: "none"
+  VpcStackName:
+    Description: The stack containing VPC infrastructure
+    Type: String
+    Default: "cri-vpc"
 
 Conditions:
   UseCodeSigningConfigArn:
@@ -112,8 +116,8 @@ Globals:
     VpcConfig:
       SecurityGroupIds: !If
         - IsDevPlatformDeploy
-        - [!ImportValue cri-vpc-AWSServicesEndpointSecurityGroupId]
-        - [!ImportValue cri-vpc-LambdaSecurityGroup]
+        - [Fn::ImportValue: !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"]
+        - [Fn::ImportValue: !Sub "${VpcStackName}-LambdaSecurityGroup"]
     PermissionsBoundary: !If
       - UsePermissionsBoundary
       - !Ref PermissionsBoundary
@@ -844,10 +848,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              !ImportValue cri-vpc-ProtectedSubnetIdA,
-              !ImportValue cri-vpc-ProtectedSubnetIdB,
+              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB",
             ]
-          - !Split [",", !ImportValue cri-vpc-PrivateSubnets]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-session"
@@ -1009,10 +1013,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              !ImportValue cri-vpc-ProtectedSubnetIdA,
-              !ImportValue cri-vpc-ProtectedSubnetIdB,
+              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB",
             ]
-          - !Split [",", !ImportValue cri-vpc-PrivateSubnets]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-sessionTS"
@@ -1147,10 +1151,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              !ImportValue cri-vpc-PrivateSubnetIdA,
-              !ImportValue cri-vpc-PrivateSubnetIdB,
+              Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB",
             ]
-          - !Split [",", !ImportValue cri-vpc-PrivateSubnets]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-authorization"
@@ -1262,10 +1266,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              !ImportValue cri-vpc-PrivateSubnetIdA,
-              !ImportValue cri-vpc-PrivateSubnetIdB,
+              Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB",
             ]
-          - !Split [",", !ImportValue cri-vpc-PrivateSubnets]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-authorizationTS"
@@ -1378,10 +1382,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              !ImportValue cri-vpc-ProtectedSubnetIdA,
-              !ImportValue cri-vpc-ProtectedSubnetIdB,
+              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB",
             ]
-          - !Split [",", !ImportValue cri-vpc-PrivateSubnets]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-access-token"
@@ -1494,10 +1498,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              !ImportValue cri-vpc-ProtectedSubnetIdA,
-              !ImportValue cri-vpc-ProtectedSubnetIdB,
+              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB",
             ]
-          - !Split [",", !ImportValue cri-vpc-PrivateSubnets]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-access-token-2"
@@ -2319,10 +2323,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              !ImportValue cri-vpc-PrivateSubnetIdA,
-              !ImportValue cri-vpc-PrivateSubnetIdB,
+              Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB",
             ]
-          - !Split [",", !ImportValue cri-vpc-PrivateSubnets]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-create-auth-code"

--- a/test-resources/infrastructure/template.yaml
+++ b/test-resources/infrastructure/template.yaml
@@ -154,11 +154,11 @@ Globals:
       !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
     VpcConfig:
       SecurityGroupIds:
-        - !ImportValue cri-vpc-AWSServicesEndpointSecurityGroupId
+        - Fn::ImportValue: !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
       SubnetIds: !If
         - IsDevPlatformDeploy
-        - [ !ImportValue cri-vpc-ProtectedSubnetIdA, !ImportValue cri-vpc-ProtectedSubnetIdB ]
-        - [ !ImportValue cri-vpc-PrivateSubnetIdA, !ImportValue cri-vpc-PrivateSubnetIdB ]
+        - [ Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA", Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB" ]
+        - [ Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB" ]
     Tracing: Active
     MemorySize: 1024
     Environment:
@@ -385,10 +385,10 @@ Resources:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
       VpcConfig:
         SecurityGroupIds:
-          - !ImportValue cri-vpc-AWSServicesEndpointSecurityGroupId
+          - Fn::ImportValue: !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
         SubnetIds:
-          - !ImportValue cri-vpc-PrivateSubnetIdA
-          - !ImportValue cri-vpc-PrivateSubnetIdB
+          - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
+          - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: AuditEventDequeueFunction


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Make the VPC stack name configurable, but continue to default it to `cri-vpc`.

### What changed

<!-- Describe the changes in detail - the "what"-->

Currently the VPC stack name defaults to `cri-vpc`, because all CRIs use this as the name of the VPC stack. This change continues to use the default value of `cri-vpc` for the VPC stack name but allows it to be overridden.

The `test-resources/infrastructure/template.yaml` already allowed the VPC stack name to be overridden, but wasn't using the configured value consistently, so this has also been updated to ensure that all stacks in this repo work the same way.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

We would like to start using this common code to deploy an OAuth server for the Stored Identity Service (SIS), which is not a CRI, and currently names its VPC stack as `vpc`. Deploying these stacks for SIS currently fails because it cannot find a stack named `cri-vpc`.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [SPT-1933](https://govukverify.atlassian.net/browse/SPT-1933)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[SPT-1933]: https://govukverify.atlassian.net/browse/SPT-1933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ