### PR TITLE
SPT-1933: Don't create SSM parameter for decryption key if not required

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -106,6 +106,9 @@ Conditions:
   UseCustomerManagedKey: !Equals
     - !FindInMap [CustomerManagedKey, !Ref "CriIdentifier", useCMK]
     - true
+  IsEncryptionKeyIdRequired: !Or
+    - !Equals [ !FindInMap [KeyRotationMapping, !Ref CriIdentifier, !Ref Environment], "false" ]
+    - !Equals [ !FindInMap [KeyRotationLegacyFallBackMapping, !Ref CriIdentifier, !Ref Environment], "true" ]
 
 Globals:
   Function:
@@ -1040,8 +1043,11 @@ Resources:
         - SQSSendMessagePolicy:
             QueueName:
               Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueName
-        - KMSDecryptPolicy:
-            KeyId: !ImportValue core-infrastructure-CriDecryptionKey1Id
+        - !If
+          - IsEncryptionKeyIdRequired
+          - KMSDecryptPolicy:
+              KeyId: !ImportValue core-infrastructure-CriDecryptionKey1Id
+          - !Ref AWS::NoValue
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoTablesEncryptionKey
         - SSMParameterReadPolicy:
@@ -2181,6 +2187,7 @@ Resources:
 
   AuthRequestKmsEncryptionKeyIdParameter:
     Type: AWS::SSM::Parameter
+    Condition: IsEncryptionKeyIdRequired
     Properties:
       Name: !Sub "/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
       Type: String

--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -114,6 +114,7 @@ export class SessionLambda implements LambdaInterface {
         };
     }
 }
+
 const ssmClient = createClient(AwsClientType.SSM);
 const configService = new ConfigService(new SSMProvider({ awsSdkV3Client: ssmClient }));
 const jweDecrypter = new JweDecrypter(kmsClient, () => configService.getConfigEntry(CommonConfigKey.DECRYPTION_KEY_ID));
@@ -122,6 +123,10 @@ const handlerClass = new SessionLambda(
     new SessionService(dynamoDbClient, configService),
     new PersonIdentityService(dynamoDbClient, configService),
 );
+const requireDecryptionKeyId =
+    process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION === "false" ||
+    process.env.ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK === "true";
+
 export const lambdaHandler = middy(handlerClass.handler.bind(handlerClass))
     .use(
         errorMiddleware(logger, {
@@ -137,8 +142,8 @@ export const lambdaHandler = middy(handlerClass.handler.bind(handlerClass))
                 CommonConfigKey.SESSION_TABLE_NAME,
                 CommonConfigKey.SESSION_TTL,
                 CommonConfigKey.PERSON_IDENTITY_TABLE_NAME,
-                CommonConfigKey.DECRYPTION_KEY_ID,
                 CommonConfigKey.VC_ISSUER,
+                ...(requireDecryptionKeyId ? [CommonConfigKey.DECRYPTION_KEY_ID] : []),
             ],
         }),
     )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Do not create the SSM parameter `/${AWS::StackName}/AuthRequestKmsEncryptionKeyId` SSM parameter if it is not used to decrypt a the JAR on the authorization request.

### What changed

<!-- Describe the changes in detail - the "what"-->

There are feature flags that control whether the decryption key used is referenced by a key ID stored in an SSM parameter or by KMS aliases. When the feature flags are set in such a way that the key id in SSM is
never used to decrypt, the session function still tries to read it from SSM.

This commit ensures that in this case, the SSM parameter is not created at all and the TS session function does not require it to exist, both from within the TypeScript and CloudFormation code.

The Java session function appears to ignore the feature flags and always requires the decryption key ID (instead of alias) and so the change has been made to the TypeScript function only and not the Java one.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

The value of this SSM parameter is populated from the output of the `core-infrastructure` stack. This stack does not exist within the Stored Identity Service, for which we want to deploy the Session Lambda, and this change allows a deployment without the `core-infrastructure` stack assuming the feature flags are set as:

`ENV_VAR_FEATURE_FLAG_KEY_ROTATION = true`
`ENV_VAR_FEATURE_FLAG_KEY_ROTATION_LEGACY_KEY_FALLBACK = false`

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [SPT-1933](https://govukverify.atlassian.net/browse/SPT-1933)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[SPT-1933]: https://govukverify.atlassian.net/browse/SPT-1933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ