### PR TITLE
SPT-1933: Rename VpcStackName parameter

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -61,8 +61,12 @@ Parameters:
     Description: The topic to publish notification and sns alerts
     Type: String
     Default: "none"
-  VpcStackName:
-    Description: The stack containing VPC infrastructure
+  VpcStackNameOverride:
+    Description: "The name of the stack containing VPC infrastructure. This parameter will be renamed to VpcStackName 
+    in line with a similar parameter set on the pipeline. However, some of the pipelines currently set VpcStackName to 
+    None, which is not a valid value for the parameter in this template. This parameter will be renamed once the 
+    pipelines are updated to set the VpcStackName explicitly, or not at all (thus relying on the default value in the 
+    template)."
     Type: String
     Default: "cri-vpc"
   IsCredentialIssuer:
@@ -133,8 +137,8 @@ Globals:
     VpcConfig:
       SecurityGroupIds: !If
         - IsDevPlatformDeploy
-        - [Fn::ImportValue: !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"]
-        - [Fn::ImportValue: !Sub "${VpcStackName}-LambdaSecurityGroup"]
+        - [Fn::ImportValue: !Sub "${VpcStackNameOverride}-AWSServicesEndpointSecurityGroupId"]
+        - [Fn::ImportValue: !Sub "${VpcStackNameOverride}-LambdaSecurityGroup"]
     PermissionsBoundary: !If
       - UsePermissionsBoundary
       - !Ref PermissionsBoundary
@@ -865,10 +869,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA",
-              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-ProtectedSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-ProtectedSubnetIdB",
             ]
-          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-session"
@@ -1030,10 +1034,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA",
-              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-ProtectedSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-ProtectedSubnetIdB",
             ]
-          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-sessionTS"
@@ -1171,10 +1175,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA",
-              Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnetIdB",
             ]
-          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-authorization"
@@ -1286,10 +1290,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA",
-              Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnetIdB",
             ]
-          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-authorizationTS"
@@ -1402,10 +1406,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA",
-              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-ProtectedSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-ProtectedSubnetIdB",
             ]
-          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-access-token"
@@ -1518,10 +1522,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA",
-              Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-ProtectedSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-ProtectedSubnetIdB",
             ]
-          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-access-token-2"
@@ -2346,10 +2350,10 @@ Resources:
         SubnetIds: !If
           - IsDevPlatformDeploy
           - [
-              Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA",
-              Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnetIdA",
+              Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnetIdB",
             ]
-          - !Split [",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets"]
+          - !Split [",", Fn::ImportValue: !Sub "${VpcStackNameOverride}-PrivateSubnets"]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-create-auth-code"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

A previous PR introduced a parameter that made the VPC stack name configurable https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/719

This commit temporarily renames that parameter from `VpcStackName` to `VpcStack`.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

Currently some CRI pipelines purposefully set VpcStackName to None which overrides the defaul value set for the parameter in the template - cri-vpc - and causes the deployment in the pipeline to fail. This temporarily renames the parameter in the template so that it does not get overriden in the pipeline, until we can hopefully update the pipelines to either explicitly set the value to `cri-vpc` or not set it at all.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [SPT-1933](https://govukverify.atlassian.net/browse/SPT-1933)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[SPT-1933]: https://govukverify.atlassian.net/browse/SPT-1933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ