### PR TITLE
BAU: Update VC assertions in headless journey script

### DIFF
--- a/test-resources/headless-journey-script/src/index.ts
+++ b/test-resources/headless-journey-script/src/index.ts
@@ -143,10 +143,7 @@ describe(`Completes ${input.journeyIdentifier} OAuth journey`, { concurrency: fa
         const [header, payload] = [headerJSON, payloadJSON].map((v) => JSON.parse(v));
 
         assert(header.typ && header.alg && header.kid);
-        assert(
-            payload.sub && payload.nbf && payload.iss && payload.exp && payload.vc,
-            // && payload.jti | not all CRIs return jti
-        );
+        assert(payload.sub && payload.nbf && payload.iss && payload.vc && payload.jti);
 
         environment.vcPayload = payload;
     });


### PR DESCRIPTION
## Proposed changes

### What changed

- Previously, Orange CRIs were setting `exp` and not always setting `jti` in their VCs
- We now expect all CRIs to set `jti` and not set `exp`
- This PR updates the assertions performed on the VC to reflect this

### Issue tracking

- OJ-3391
- OJ-3724

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
