### PR TITLE
Remove unused publicSigningJwkBase64 param from headless-core-stub

### DIFF
--- a/.github/workflows/package-test-resources.yml
+++ b/.github/workflows/package-test-resources.yml
@@ -30,6 +30,10 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
           scope: "@govuk-one-login"
           always-auth: true
+  
+      - name: Clear SAM build cache
+        shell: bash
+        run: rm -rf .aws-sam/cache
 
       - name: Build SAM application
         id: build

--- a/.github/workflows/package-test-resources.yml
+++ b/.github/workflows/package-test-resources.yml
@@ -36,7 +36,7 @@ jobs:
         uses: govuk-one-login/github-actions/sam/build-application@c9c3f2ef04d9145894de83e973b0f4dc1e90d14e
         with:
           template: test-resources/infrastructure/template.yaml
-          source-dir: test-resources/**/lambdas/src
+          source-dir: test-resources
           cache-name: test-resources
 
   publish:

--- a/test-resources/headless-core-stub/utils/src/services/client-configuration.ts
+++ b/test-resources/headless-core-stub/utils/src/services/client-configuration.ts
@@ -8,7 +8,6 @@ export class ClientConfiguration {
             `/${commonStackName}/clients/${clientId}/jwtAuthentication/audience`,
             `/${commonStackName}/clients/${clientId}/jwtAuthentication/issuer`,
             `/${commonStackName}/clients/${clientId}/jwtAuthentication/redirectUri`,
-            `/${commonStackName}/clients/${clientId}/jwtAuthentication/publicSigningJwkBase64`,
             `/test-resources/${clientId}/privateSigningKey`,
         ];
         return getParametersValues(parameters);

--- a/test-resources/headless-core-stub/utils/tests/services/client-configuration.test.ts
+++ b/test-resources/headless-core-stub/utils/tests/services/client-configuration.test.ts
@@ -26,7 +26,6 @@ describe("getConfig", () => {
             `/${commonStackName}/clients/${clientId}/jwtAuthentication/audience`,
             `/${commonStackName}/clients/${clientId}/jwtAuthentication/issuer`,
             `/${commonStackName}/clients/${clientId}/jwtAuthentication/redirectUri`,
-            `/${commonStackName}/clients/${clientId}/jwtAuthentication/publicSigningJwkBase64`,
             `/test-resources/${clientId}/privateSigningKey`,
         ];
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Remove `publicSigningJwkBase64` SSM parameter fetch from headless-core-stub



### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
When using the headless core stub alongside oauth common, which doesn't create this parameter, the fetch fails.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->


## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


### Other considerations

I had to make fixes to the package-test-resources workflow so that this change would get picked up:
- Update `source-dir` build cache key to include all source files
- Clear SAM build cache before building test-resources

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
