### PR TITLE
feat: update session lambda to return `govuk_signin_journey_id`

### DIFF
--- a/lambdas/src/handlers/session-handler.ts
+++ b/lambdas/src/handlers/session-handler.ts
@@ -92,6 +92,7 @@ export class SessionLambda implements LambdaInterface {
                     session_id: sessionItem.sessionId,
                     state: jwtPayload.state,
                     redirect_uri: jwtPayload.redirect_uri,
+                    govuk_signin_journey_id: sessionRequestSummary.clientSessionId,
                 }),
             };
         } catch (err: unknown) {

--- a/lambdas/tests/unit/handlers/session-handler.test.ts
+++ b/lambdas/tests/unit/handlers/session-handler.test.ts
@@ -460,6 +460,7 @@ describe("SessionLambda", () => {
             session_id: "test-session-id",
             state: "test-state",
             redirect_uri: "test-redirect-uri",
+            govuk_signin_journey_id: "test-journey-id",
         });
         expect(result.statusCode).toBe(201);
     });


### PR DESCRIPTION
## Proposed changes

### Why did it change
This will allow FEs to have access to the `govuk_signin_journey_id` so that we can correlate backend and frontend logs together. 

### Issue tracking
- [OJ-3667](https://govukverify.atlassian.net/browse/OJ-3667)


[OJ-3667]: https://govukverify.atlassian.net/browse/OJ-3667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ