### PR TITLE
Migrate Address Pact tests to check TS OAuth Lambdas

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cri-provider: ["PassportTokenProvider","DrivingLicenceTokenProvider","FraudTokenProvider","AddressCriTokenProvider"]
+        cri-provider: ["PassportTokenProvider","DrivingLicenceTokenProvider","FraudTokenProvider"]
     uses: ./.github/workflows/run-pact-tests-java.yml
     with:
       cri-provider: ${{ matrix.cri-provider }}
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cri-provider: ["ExperianKbvCriTokenProvider","NinoCriTokenProvider"]
+        cri-provider: ["ExperianKbvCriTokenProvider","NinoCriTokenProvider","AddressCriTokenProvider"]
     uses: ./.github/workflows/run-pact-tests-ts.yml
     with:
       cri-provider: ${{ matrix.cri-provider }}

--- a/lambdas/tests/unit/handlers/contract/access-token-provider.test.ts
+++ b/lambdas/tests/unit/handlers/contract/access-token-provider.test.ts
@@ -14,20 +14,19 @@ const logger = new Logger({
 
 describe("Pact Verification", () => {
     let componentId: string;
-    const experianStates = {
+    const stateHandlers = {
         "dummyExperianKbvComponentId is the experianKbv CRI component ID": async () => {
             componentId = "dummyExperianKbvComponentId";
-            return Promise.resolve({ description: "ComponentId set" });
+            return { description: "ComponentId set" };
         },
-        "ExperianKbv CRI uses CORE_BACK_SIGNING_PRIVATE_KEY_JWK to validate core signatures": async () =>
-            Promise.resolve(),
-    };
-    const checkHmrcNinoStates = {
         "dummyNinoComponentId is the NINO CRI component ID": async () => {
             componentId = "dummyNinoComponentId";
-            return Promise.resolve({ description: "ComponentId set" });
+            return { description: "ComponentId set" };
         },
-        "NINO CRI uses CORE_BACK_SIGNING_PRIVATE_KEY_JWK to validate core signatures": async () => Promise.resolve(),
+        "dummyAddressComponentId is the address CRI component ID": async () => {
+            componentId = "dummyAddressComponentId";
+            return { description: "ComponentId set" };
+        },
     };
 
     const verifierOptions: VerifierOptions = {
@@ -38,10 +37,7 @@ describe("Pact Verification", () => {
         pactBrokerPassword: process.env.PACT_BROKER_PASSWORD,
         consumerVersionSelectors: [{ mainBranch: true }, { deployedOrReleased: true }],
         publishVerificationResult: true,
-        stateHandlers: {
-            ...experianStates,
-            ...checkHmrcNinoStates,
-        },
+        stateHandlers,
         requestFilter: (req, _res, next) => {
             req.headers["component-id"] = componentId;
             // This should not be required, but we were seeing a strange bug where pact was not generating the request with the correct content-length


### PR DESCRIPTION
## Proposed changes

### What changed

- Added Address CRI entry to state handlers in TS Pact config
- Simplified state handlers, removing no-op entries and unnecessary `Promise.resolve()` calls
- Removed Address CRI provider from Java contract test workflow
- Added Address CRI provider to TS contract test workflow

### Why did it change

- We use the TS access token function in Address CRI so our tests should represent this

### Issue tracking

- OJ-3575

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks
