### PR TITLE
chore: disable sonar for Java

### DIFF
--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -37,56 +37,6 @@ jobs:
     secrets:
       npm-token: ${{ secrets.GITHUB_TOKEN }}
 
-  sonarcloud-java:
-    name: SonarCloud / Java
-    needs: unit-tests-java
-    runs-on: ubuntu-latest
-    steps:
-      - name: Pull repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: 7.5.1
-
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: zulu
-          cache: gradle
-
-      - name: Cache build artifacts
-        uses: actions/cache@v4
-        with:
-          key: ${{ runner.os }}-common-lambdas-java-${{ github.head_ref || github.ref_name }}
-          restore-keys: ${{ runner.os }}-common-lambdas-java-
-          path: |
-            **/*/build/
-            !**/*/build/jacoco
-            !**/*/build/reports
-
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-          path: ~/.sonar/cache
-
-      - name: Get coverage results
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.unit-tests-java.outputs.coverage-artifact }}
-
-      - name: Run SonarCloud scan
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_JAVA }}
-        run: ./gradlew sonar --build-cache --parallel --info
-
   sonarcloud-ts:
     name: SonarCloud / TypeScript
     needs: unit-tests-ts


### PR DESCRIPTION
## Proposed changes

### What changed
Disable Sonar check for Java

### Why did it change
Sonar no longer supports Java 17 - we need to upgrade to Java 21. Nobody is using Java common-lambdas anymore and we will soon archive this repo in favour of common-oauth so it's better to just remove that check as opposed to upgrading Gradle in this repo. 
