### PR TITLE
Remove KBV-specific X-Forwarded-For header from session request

### DIFF
--- a/test-resources/headless-journey-script/README.md
+++ b/test-resources/headless-journey-script/README.md
@@ -29,6 +29,7 @@ npm run journey -- \
   --privateApiGatewayId abcdefghij \
   --publicApiGatewayId klmnopqrst
 ```
+For more detailed output, add the `--verbose` flag when running the journey:
 
 AWS authentication is used to retrieve information from AWS and invoke API Gateways with your credentials, using the
 same functionality as the 'Test' tab in the AWS API Gateway dashboard. The gateways are invoked in this way to ensure

--- a/test-resources/headless-journey-script/src/index.ts
+++ b/test-resources/headless-journey-script/src/index.ts
@@ -44,10 +44,6 @@ describe(`Completes ${input.journeyIdentifier} OAuth journey`, { concurrency: fa
         const response = await invokeApi("private", {
             method: "POST",
             path: "/session",
-            headers: {
-                // Experian KBV CRI requires this
-                "X-Forwarded-For": "0.0.0.0",
-            },
             jsonBody: {
                 request: environment.sessionJar,
                 client_id: environment.clientId,


### PR DESCRIPTION
## Proposed changes

### What changed
Removed the X-Forwarded-For header from the headless journey script session request.

### Why did it change
The X-Forwarded-For header was previously included to support KBV's session endpoint configuration. As CRIs are being aligned to use the same optional header configuration as Check HMRC, the headless journey script no longer needs to send this header, reducing CRI-specific behaviour in test tooling.

### Issue tracking

- [OJ-3801](https://govukverify.atlassian.net/browse/OJ-3801)


[OJ-3801]: https://govukverify.atlassian.net/browse/OJ-3801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ